### PR TITLE
Initialize hosts on startup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,9 @@ mod models;
 mod schema;
 mod services;
 
+use rocket::fairing::AdHoc;
 use rocket::Rocket;
+use rocket::State;
 
 use controllers::hosts;
 use controllers::vms;
@@ -32,6 +34,10 @@ pub fn rocket() -> Rocket {
             host_service: HostService::new(),
             vm_service: VmService::new(),
         })
+        .attach(AdHoc::on_launch("Initialize hosts", |rocket| {
+            let backend: State<Backend> = State::from(rocket).unwrap();
+            backend.host_service.initialize_hosts(&DbConnection::get_one(&rocket).unwrap())
+        }))
         .mount("/hosts", hosts::routes())
         .mount("/vms", vms::routes())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,9 @@ pub fn rocket() -> Rocket {
         })
         .attach(AdHoc::on_launch("Initialize hosts", |rocket| {
             let backend: State<Backend> = State::from(rocket).unwrap();
-            backend.host_service.initialize_hosts(&DbConnection::get_one(&rocket).unwrap())
+            backend
+                .host_service
+                .initialize_hosts(&DbConnection::get_one(&rocket).unwrap())
         }))
         .mount("/hosts", hosts::routes())
         .mount("/vms", vms::routes())

--- a/src/models/host.rs
+++ b/src/models/host.rs
@@ -70,8 +70,12 @@ impl Host {
         }
     }
 
-    pub fn update_status(h: Host, new_status: Status, conn: &PgConnection) -> Result<Host, String> {
-        match diesel::update(&h)
+    pub fn update_status(
+        h: &Host,
+        new_status: Status,
+        conn: &PgConnection,
+    ) -> Result<Host, String> {
+        match diesel::update(h)
             .set(status.eq(new_status))
             .get_result(conn)
         {

--- a/src/services/host.rs
+++ b/src/services/host.rs
@@ -152,7 +152,8 @@ impl HostService {
                         Err(e) => {
                             eprintln!("Host is unhealthy {}, error: {}", host.id, e);
 
-                            // TODO: down status is not correct, need to introduce one
+                            // TODO: down status is not correct, need to introduce a new status
+                            // for this
                             Host::update_status(host, Status::Down, &*conn);
                             return ();
                         }

--- a/src/services/host.rs
+++ b/src/services/host.rs
@@ -139,7 +139,7 @@ impl HostService {
     pub fn initialize_hosts(&self, conn: &DbConnection) {
         let hosts = Host::by_status(Status::Up, conn).unwrap();
         for host in hosts {
-            // TODO: this can and should be done in parallel
+            // TODO: this can and should be done concurrently
             match Client::connect(format!("http://{}:{}", host.address, host.port)) {
                 Ok(c) => {
                     println!("Saving client for host {}", host.id);

--- a/src/services/host.rs
+++ b/src/services/host.rs
@@ -139,6 +139,7 @@ impl HostService {
     pub fn initialize_hosts(&self, conn: &DbConnection) {
         let hosts = Host::by_status(Status::Up, conn).unwrap();
         for host in hosts {
+            // TODO: this can and should be done in parallel
             match Client::connect(format!("http://{}:{}", host.address, host.port)) {
                 Ok(c) => {
                     println!("Saving client for host {}", host.id);


### PR DESCRIPTION
Preliminary work on host initialization:
When start the qarax, it will try to connect and run a health check on hosts that were last report as being UP