### PR TITLE
Basic networking

### DIFF
--- a/migrations/2020-06-22-163236_create_vms/up.sql
+++ b/migrations/2020-06-22-163236_create_vms/up.sql
@@ -6,5 +6,7 @@ CREATE TABLE vms (
     vcpu INTEGER NOT NULL,
     memory INTEGER NOT NULL,
     kernel VARCHAR(255) NOT NULL,
-    root_file_system VARCHAR(255) NOT NULL
+    root_file_system VARCHAR(255) NOT NULL,
+    address VARCHAR(16),
+    network_mode VARCHAR(10)
 )

--- a/migrations/2020-06-22-163236_create_vms/up.sql
+++ b/migrations/2020-06-22-163236_create_vms/up.sql
@@ -8,5 +8,6 @@ CREATE TABLE vms (
     kernel VARCHAR(255) NOT NULL,
     root_file_system VARCHAR(255) NOT NULL,
     address VARCHAR(16),
-    network_mode VARCHAR(10)
+    network_mode VARCHAR(10),
+    kernel_params VARCHAR(1000) NOT NULL
 )

--- a/playbooks/roles/setup_host/playbook.yml
+++ b/playbooks/roles/setup_host/playbook.yml
@@ -5,3 +5,5 @@
     - name: compile firecracker
       include: tasks/compile.yml
       when: build is defined and build == "compile"
+    - name: setup network
+      include: tasks/setup_network.yml

--- a/playbooks/roles/setup_host/playbook.yml
+++ b/playbooks/roles/setup_host/playbook.yml
@@ -1,5 +1,7 @@
 - hosts: all
   tasks:
+    - name: install prerequisits
+      include: tasks/install_prereqs.yml
     - name: install packages
       include: tasks/install.yml
     - name: compile firecracker

--- a/playbooks/roles/setup_host/tasks/files/setup_bridge.sh
+++ b/playbooks/roles/setup_host/tasks/files/setup_bridge.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+INTERFACE=$(ip route get 8.8.8.8 | awk '{ print $5; exit }')
+IP=$(hostname -I)
+IP_WITH_CIDR=$(ip addr show dev $INTERFACE | grep "inet " | awk '{print $2}')
+ROUTE=$(ip route list dev $INTERFACE | grep -v default | cut -f 1 -d ' ')
+DEFAULT_ROUTE=$(ip route list dev $INTERFACE | grep default | awk '{print $3}')
+
+ip link add fcbridge type bridge
+ip link set fcbridge up
+ip addr flush dev $INTERFACE
+ip link set $INTERFACE master fcbridge
+ip addr add $IP_WITH_CIDR brd + dev fcbridge
+ip route add default via $DEFAULT_ROUTE
+ip route add $ROUTE dev fcbridge proto kernel scope link src $IP
+exit 0

--- a/playbooks/roles/setup_host/tasks/install_prereqs.yml
+++ b/playbooks/roles/setup_host/tasks/install_prereqs.yml
@@ -1,0 +1,4 @@
+- name: install arp-scan
+  package:
+    name: arp-scan
+    state: present

--- a/playbooks/roles/setup_host/tasks/setup_network.yml
+++ b/playbooks/roles/setup_host/tasks/setup_network.yml
@@ -1,0 +1,32 @@
+- name: set ipv4 forwarding
+  sysctl:
+    name: net.ipv4.conf.all.forwarding
+    value: 1
+    state: present
+
+- name: proxy arp
+  sysctl:
+    name: net.ipv4.conf.all.proxy_arp
+    value: 1
+    state: present
+
+- name: disable ipv6
+  sysctl:
+    name: net.ipv6.conf.all.disable_ipv6
+    value: 1
+    state: present
+
+- name: copy setup_bridge.sh to host
+  copy:
+    src: ./files/setup_bridge.sh
+    dest: setup_bridge.sh
+    mode: u=rwx
+
+- name: check if bridge present
+  shell: ip addr show dev fcbridge | grep fcbridge
+  register: fcbridge
+  ignore_errors: true
+
+- name: run bridge setup
+  shell: ./setup_bridge.sh
+  when: fcbridge.rc == 1

--- a/proto/node.proto
+++ b/proto/node.proto
@@ -9,6 +9,9 @@ message VmConfig {
     int32 vcpus = 3;
     string kernel = 4;
     string rootFs = 5;
+    string kernel_params = 6;
+    string network_mode = 7;
+    string address = 8;
 }
 
 enum Status {

--- a/qarax-node/Cargo.toml
+++ b/qarax-node/Cargo.toml
@@ -16,6 +16,7 @@ tracing = "0.1"
 tracing-subscriber = "0.2"
 tracing-appender = "0.1"
 firecracker_rust_sdk = { path = "./firecracker_rust_sdk" }
+rand = "0.7.3"
 
 [build-dependencies]
 tonic-build = "0.2"

--- a/qarax-node/src/main.rs
+++ b/qarax-node/src/main.rs
@@ -1,3 +1,4 @@
+mod network;
 mod vm_service;
 mod vmm_handler;
 

--- a/qarax-node/src/network.rs
+++ b/qarax-node/src/network.rs
@@ -1,0 +1,68 @@
+use rand;
+use rand::prelude::*;
+
+use std::process::Stdio;
+use tokio::process::Command;
+
+const BRIDGE_NAME: &str = "fcbridge";
+
+pub fn generate_mac() -> String {
+    let mut buf: [u8; 6] = [0; 6];
+    rand::thread_rng().fill_bytes(&mut buf);
+    buf[0] |= 2;
+
+    format!(
+        "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+        buf[0], buf[1], buf[2], buf[3], buf[4], buf[5]
+    )
+}
+
+pub async fn get_ip(output: String, mac: &str) -> String {
+    let s: String = output.lines().filter(|l| l.contains(mac)).collect();
+
+    s.as_str().split_whitespace().next().unwrap().to_owned()
+}
+
+pub async fn create_tap_device(vm_id: &str) {
+    // TODO: use a utility or something and handle errors
+    let tap_device = &format!("fc-tap-{}", &vm_id[..4]);
+    Command::new("ip")
+        .args(vec!["tuntap", "add", tap_device, "mode", "tap"])
+        .stdout(Stdio::null())
+        .spawn()
+        .expect("failed to add tap device")
+        .await;
+
+    Command::new("ip")
+        .args(vec!["link", "set", tap_device, "up"])
+        .stdout(Stdio::null())
+        .spawn()
+        .expect("failed to set tap device up")
+        .await;
+
+    Command::new("ip")
+        .args(vec!["link", "set", tap_device, "master", BRIDGE_NAME])
+        .stdout(Stdio::null())
+        .spawn()
+        .expect("failed to add tap device to bridge")
+        .await;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tokio::runtime::Builder;
+
+    #[test]
+    fn test() {
+        let mut rt = Builder::new()
+            .basic_scheduler()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let input = String::from("Interface: fcbridge, type: EN10MB, MAC: f6:17:27:50:93:84, IPv4: 192.168.122.45\nStarting arp-scan 1.9.7 with 256 hosts (https://github.com/royhills/arp-scan)\n192.168.122.1\t52:54:00:9b:d5:cc\tQEMU\n\n1 packets received by filter, 0 packets dropped by kernel\nEnding arp-scan 1.9.7: 256 hosts scanned in 1.898 seconds (134.88 hosts/sec). 1 responded\n");
+        let out = rt.block_on(get_ip(input, "52:54:00:9b:d5:cc"));
+        assert_eq!(out, "192.168.122.1")
+    }
+}

--- a/qarax-node/src/vm_service.rs
+++ b/qarax-node/src/vm_service.rs
@@ -5,7 +5,6 @@ use crate::vmm_handler::node::{
 use crate::vmm_handler::VmmHandler;
 
 use std::collections::HashMap;
-
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tonic::{Code, Request, Response, Status};

--- a/src/models/vm.rs
+++ b/src/models/vm.rs
@@ -29,7 +29,7 @@ pub struct NewVm {
     pub memory: i32,
     pub kernel: String,
     pub root_file_system: String,
-    pub network_mode: Option<NetworkMode>,
+    pub network_mode: Option<NetworkMode>, // TODO: remove option and use (DHCP, STATIC_IP, NONE)
     pub address: Option<String>,
     pub kernel_params: Option<String>,
 }
@@ -40,6 +40,7 @@ pub enum NetworkMode {
     Dhcp,
     #[serde(rename = "static_ip")]
     StaticIp,
+    // TODO: add default None
 }
 
 impl NetworkMode {

--- a/src/models/vm.rs
+++ b/src/models/vm.rs
@@ -4,6 +4,8 @@ use diesel::PgConnection;
 use std::convert::From;
 use uuid::Uuid;
 
+const DEFAUL_KERNEL_PARAMS: &str = "console=ttyS0 reboot=k panic=1 pci=off";
+
 #[derive(Insertable, Identifiable, Serialize, Deserialize, Queryable, Debug)]
 #[table_name = "vms"]
 pub struct Vm {
@@ -17,6 +19,7 @@ pub struct Vm {
     pub root_file_system: String,
     pub address: Option<String>,
     pub network_mode: Option<String>,
+    pub kernel_params: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -28,6 +31,7 @@ pub struct NewVm {
     pub root_file_system: String,
     pub network_mode: Option<NetworkMode>,
     pub address: Option<String>,
+    pub kernel_params: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -92,6 +96,11 @@ impl From<&NewVm> for Vm {
             String::from("")
         };
 
+        let kernel_params = match &nv.kernel_params {
+            Some(kp) => kp.to_owned(),
+            None => String::from(DEFAUL_KERNEL_PARAMS),
+        };
+
         Vm {
             id: Uuid::new_v4(),
             name: nv.name.to_owned(),
@@ -103,6 +112,7 @@ impl From<&NewVm> for Vm {
             root_file_system: nv.root_file_system.to_owned(),
             address: Some(address),
             network_mode,
+            kernel_params,
         }
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -20,6 +20,8 @@ table! {
         memory -> Int4,
         kernel -> Varchar,
         root_file_system -> Varchar,
+        address -> Nullable<Varchar>,
+        network_mode -> Nullable<Varchar>,
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -22,6 +22,7 @@ table! {
         root_file_system -> Varchar,
         address -> Nullable<Varchar>,
         network_mode -> Nullable<Varchar>,
+        kernel_params -> Varchar,
     }
 }
 

--- a/src/services/vm.rs
+++ b/src/services/vm.rs
@@ -67,4 +67,12 @@ impl VmService {
 
         Ok(Uuid::parse_str(vm_id).unwrap())
     }
+
+    #[allow(dead_code)]
+    pub fn delete_all(&self, conn: &DbConnection) -> Result<usize, String> {
+        match Vm::delete_all(conn) {
+            Ok(record_count) => Ok(record_count),
+            Err(e) => Err(e.to_string()),
+        }
+    }
 }

--- a/src/services/vm.rs
+++ b/src/services/vm.rs
@@ -42,6 +42,9 @@ impl VmService {
             vcpus: vm.vcpu,
             kernel: vm.kernel,
             root_fs: vm.root_file_system,
+            kernel_params: vm.kernel_params,
+            network_mode: vm.network_mode.unwrap_or(String::from("")),
+            address: vm.address.unwrap_or(String::from("")),
         };
 
         client.start_vm(request);


### PR DESCRIPTION
Implement DHCP based networking:
1. Setup the bridge upon installing the host. TODO: make the bridge persistent
2. Introduce the `network_mode` field, currently accepts `static_ip` and `dhcp`, `static_ip` is not currently implemented.
3. By choosing `dhcp` an `ip=dhcp` kernel parameter will be added in qarax-node
4. A MAC address will be generated for the guest. TODO: allow the user to choose it
5. Create a tap device of the form `fc-tap-{first-4-letters-of-vm-ID}` 
6. A request to the `/network-interfaces/` endpoint with the details will be made.
7. After the VM has started, a 5 second sleep will start (terrible), after which an `arp-scan -l` will be isseud to find out the VM's IP address. TODO: this should be made async and not block the VM startup.

Additional TODOs:
1. Update the VM in qarax's database once the IP is discovered
2. Figure out whether there's a better way to figure out the IP than issuing an `arp-scan`