### PR TITLE
DHCP improvements

### DIFF
--- a/playbooks/roles/setup_host/playbook.yml
+++ b/playbooks/roles/setup_host/playbook.yml
@@ -1,7 +1,5 @@
 - hosts: all
   tasks:
-    - name: install prerequisits
-      include: tasks/install_prereqs.yml
     - name: install packages
       include: tasks/install.yml
     - name: compile firecracker

--- a/playbooks/roles/setup_host/tasks/install_prereqs.yml
+++ b/playbooks/roles/setup_host/tasks/install_prereqs.yml
@@ -1,4 +1,0 @@
-- name: install arp-scan
-  package:
-    name: arp-scan
-    state: present

--- a/qarax-node/Cargo.toml
+++ b/qarax-node/Cargo.toml
@@ -17,6 +17,7 @@ tracing-subscriber = "0.2"
 tracing-appender = "0.1"
 firecracker_rust_sdk = { path = "./firecracker_rust_sdk" }
 rand = "0.7.3"
+smoltcp = { git = "https://github.com/bennyz/smoltcp", branch = "qarax-branch", features= ["proto-dhcpv4", "log"]}
 
 [build-dependencies]
 tonic-build = "0.2"

--- a/qarax-node/src/network/dhcp.rs
+++ b/qarax-node/src/network/dhcp.rs
@@ -1,0 +1,85 @@
+use crate::network::MacAddress;
+use smoltcp::dhcp::{ClientState, Dhcpv4Client};
+use smoltcp::iface::{EthernetInterfaceBuilder, NeighborCache, Routes};
+use smoltcp::phy::wait as phy_wait;
+use smoltcp::phy::TapInterface;
+use smoltcp::socket::{RawPacketMetadata, RawSocketBuffer, SocketSet};
+use smoltcp::time::Instant;
+use smoltcp::wire::{EthernetAddress, IpCidr, Ipv4Address};
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::os::unix::io::AsRawFd;
+
+// Get an IP address from the DHCP server, based on https://github.com/smoltcp-rs/smoltcp/blob/master/examples/dhcp_client.rs
+pub fn get_ip(
+    mac_address: MacAddress,
+    tap_device: &str,
+) -> Result<String, Box<dyn Error + Sync + Send>> {
+    tracing::info!("Starting DHCP client...");
+
+    let mut sockets = SocketSet::new(vec![]);
+    let tx_buffer = RawSocketBuffer::new([RawPacketMetadata::EMPTY; 1], vec![0; 600]);
+    let rx_buffer = RawSocketBuffer::new([RawPacketMetadata::EMPTY; 1], vec![0; 600]);
+    let tap = TapInterface::new(tap_device).unwrap();
+    let mut routes_storage = [None; 1];
+    let routes = Routes::new(&mut routes_storage[..]);
+    let fd = tap.as_raw_fd();
+
+    let mut iface = EthernetInterfaceBuilder::new(tap)
+        .neighbor_cache(NeighborCache::new(BTreeMap::new()))
+        .any_ip(true)
+        .ip_addrs([IpCidr::new(Ipv4Address::UNSPECIFIED.into(), 0)])
+        .ethernet_addr(EthernetAddress(mac_address.0))
+        .routes(routes)
+        .finalize();
+
+    let mut dhcp = Dhcpv4Client::new(&mut sockets, rx_buffer, tx_buffer, Instant::now());
+    let mut ip_address = String::new();
+    loop {
+        match dhcp.state {
+            ClientState::Renew(_) => {
+                tracing::info!(
+                    "Got an ACK from DHCP server, return IP address '{}'",
+                    ip_address
+                );
+                break Ok(ip_address);
+            }
+            _ => {}
+        }
+
+        let timestamp = Instant::now();
+        iface
+            .poll(&mut sockets, timestamp)
+            .map(|_| ())
+            .unwrap_or_else(|e| tracing::debug!("Poll: {:?}", e));
+        let config = dhcp
+            .poll(&mut iface, &mut sockets, timestamp)
+            .unwrap_or_else(|e| {
+                tracing::info!("err: {}", e);
+                None
+            });
+
+        match config {
+            Some(c) => {
+                if c.address.is_some() {
+                    iface.update_ip_addrs(|addrs| {
+                        addrs.iter_mut().nth(0).map(|addr| {
+                            *addr = IpCidr::Ipv4(c.address.unwrap());
+                        });
+                    });
+                    ip_address = c.address.unwrap().address().to_string();
+                    tracing::info!("Assigned an IPv4 address: {}", c.address.unwrap());
+                }
+            }
+
+            None => {}
+        };
+
+        let mut timeout = dhcp.next_poll(timestamp);
+        dhcp.next_poll(Instant::now());
+        iface
+            .poll_delay(&sockets, timestamp)
+            .map(|sockets_timeout| timeout = sockets_timeout);
+        phy_wait(fd, Some(timeout)).unwrap_or_else(|e| tracing::info!("Wait: {:?}", e));
+    }
+}

--- a/qarax-node/src/vmm_handler.rs
+++ b/qarax-node/src/vmm_handler.rs
@@ -52,7 +52,12 @@ impl VmmHandler {
 
         // TODO: use an enum like civilized person
         if vm_config.network_mode == "dhcp" {
-            network = Some(Self::configure_network(&mut bs, &vm_config.vm_id));
+            let mac = network::generate_mac();
+            tracing::info!("Generated MAC address: '{}'", mac);
+
+            let ip = network::get_ip(Arc::new(mac), Arc::new(get_tap_device(&vm_config.vm_id))).await.unwrap();
+            tracing::info!("Assigning IP '{}' for VM {}", ip, &vm_config.vm_id);
+            network = Some(Self::configure_network(&mut bs, &vm_config.vm_id, mac));
         }
 
         // TODO: move into own function and handle errors
@@ -107,26 +112,6 @@ impl VmmHandler {
             tracing::info!("Starting VM machine...");
             m.as_ref().unwrap().start().await;
             tracing::info!("machine started");
-
-            // TODO: find a better way to do polling and definitly do not block the request
-            use std::{thread, time};
-            thread::sleep(time::Duration::from_millis(5000));
-
-            // TODO: there has got to be a better way
-            let mac = m
-                .as_ref()
-                .unwrap()
-                .network
-                .as_ref()
-                .unwrap()
-                .guest_mac
-                .as_ref()
-                .unwrap();
-            // TODO: use -q, -x, -I options
-            let arp_scan = Command::new("arp-scan").arg("-l").output().await;
-            let ip =
-                network::get_ip(String::from_utf8(arp_scan.unwrap().stdout).unwrap(), &mac).await;
-            tracing::info!("ip address: {}", ip);
         } else {
             tracing::error!("Machine object unavilable! - start");
         }
@@ -155,19 +140,24 @@ impl VmmHandler {
     fn configure_network(
         bs: &mut boot_source::BootSource,
         vm_id: &str,
+        mac: network::MacAddress,
     ) -> network_interface::NetworkInterface {
         // TODO: implement static ip as well
         bs.boot_args = format!("{} ip=dhcp", bs.boot_args);
 
         network_interface::NetworkInterface {
-            guest_mac: Some(network::generate_mac()),
-            host_dev_name: format!("fc-tap-{}", &vm_id[..4]),
+            guest_mac: Some(mac.to_string()),
+            host_dev_name: get_tap_device(vm_id),
             iface_id: String::from("1"), // TODO: assign a normal ID
             allow_mmds_requests: None,
             rx_rate_limiter: None,
             tx_rate_limiter: None,
         }
     }
+}
+
+fn get_tap_device(vm_id: &str) -> String {
+    format!("fc-tap-{}", &vm_id[..4])
 }
 
 impl TryFrom<i32> for Status {

--- a/qarax-node/src/vmm_handler.rs
+++ b/qarax-node/src/vmm_handler.rs
@@ -55,7 +55,9 @@ impl VmmHandler {
             let mac = network::generate_mac();
             tracing::info!("Generated MAC address: '{}'", mac);
 
+            // TODO: The IP should be sent back to qarax
             let ip = network::get_ip(Arc::new(mac), Arc::new(get_tap_device(&vm_config.vm_id))).await.unwrap();
+
             tracing::info!("Assigning IP '{}' for VM {}", ip, &vm_config.vm_id);
             network = Some(Self::configure_network(&mut bs, &vm_config.vm_id, mac));
         }
@@ -156,6 +158,7 @@ impl VmmHandler {
     }
 }
 
+// TODO: turn this into a macro or something
 fn get_tap_device(vm_id: &str) -> String {
     format!("fc-tap-{}", &vm_id[..4])
 }


### PR DESCRIPTION
Use the `smoltcp` DHCP client to request an IP for the VM before it is started.
Once an ACK is received, the VM is started with an `ip=dhcp` kernel parameter which will assign the same IP we previously requested, relieving us from having to perform hacks with `arp-scan`