### PR TITLE
perform host healthcheck on startup

### DIFF
--- a/src/handlers/models/hosts.rs
+++ b/src/handlers/models/hosts.rs
@@ -106,7 +106,6 @@ WHERE id = $1
 }
 
 pub async fn by_status(pool: &PgPool, status: Status) -> Result<Vec<Host>, HostError> {
-    tracing::info!("status {}", status.to_string());
     let hosts = sqlx::query_as!(
         Host,
         r#"
@@ -123,7 +122,11 @@ WHERE status = $1
     Ok(hosts)
 }
 
-pub async fn update_status(pool: &PgPool, host_id: Uuid, status: Status) -> anyhow::Result<bool> {
+pub async fn update_status(
+    pool: &PgPool,
+    host_id: Uuid,
+    status: Status,
+) -> Result<bool, HostError> {
     let row_affected = sqlx::query!(
         r#"
 UPDATE hosts

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let addr = SocketAddr::from(([127, 0, 0, 1], args.port));
     tracing::info!("listening on {}", addr);
     axum::Server::bind(&addr)
-        .serve(handlers::app(environment).into_make_service())
+        .serve(handlers::app(&environment).await.into_make_service())
         .await?;
 
     Ok(())


### PR DESCRIPTION
When the server is started, verify that each host in status up is still
reachable (that is, qarax-node is responding to a healthcheck).
As well as check hosts that were previously in unknown status.

Hosts will move to "initializing" status during the healthcheck and move
to either "up" or "unknown" depending on the result of the healthcheck.

fixes #108 