### PR TITLE
make ssh key location configurable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,3 +3,4 @@ TEST_DATABASE_URL=postgres://postgres@localhost/qarax_test
 SQLX_OFFLINE=true
 FC_VERSION=0.25.0
 LOCAL_NODE_PATH=/path/to/qarax
+SSH_PUB_KEY=/path/to/ssh_key.pub

--- a/playbooks/roles/setup_host/tasks/prologue.yml
+++ b/playbooks/roles/setup_host/tasks/prologue.yml
@@ -1,5 +1,7 @@
 - name: Set authorized key taken from file
+  vars:
+    ssh_key_location: "{{ lookup('env','SSH_PUB_KEY') }}"
   ansible.posix.authorized_key:
     user: root
     state: present
-    key: "{{ lookup('file', lookup('env','HOME') + '/.ssh/id_ed25519.pub') }}"
+    key: "{{ lookup('file', ssh_key_location) }}"


### PR DESCRIPTION
SSH_PUB_KEY env var will be used to determine the location of the SSH
key, if it's not set, no SSH key will be copied.

Fixes #112