### PR TITLE
Add HA VM failover support

### DIFF
--- a/.sqlx/query-5803cd6957856f8bbad1b62ec72c6bb7c8da4095972247f6b43dd182a71595b8.json
+++ b/.sqlx/query-5803cd6957856f8bbad1b62ec72c6bb7c8da4095972247f6b43dd182a71595b8.json
@@ -1,0 +1,209 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\nSELECT id,\n        name,\n        tags as \"tags!\",\n        status as \"status: _\",\n        host_id as \"host_id?\",\n        hypervisor as \"hypervisor: _\",\n        boot_source_id as \"boot_source_id?\",\n        boot_mode as \"boot_mode: _\",\n        description as \"description?\",\n        boot_vcpus,\n        max_vcpus,\n        cpu_topology as \"cpu_topology: _\",\n        kvm_hyperv as \"kvm_hyperv!\",\n        memory_size,\n        memory_hotplug_size as \"memory_hotplug_size?\",\n        memory_mergeable as \"memory_mergeable!\",\n        memory_shared as \"memory_shared!\",\n        memory_hugepages as \"memory_hugepages!\",\n        memory_hugepage_size as \"memory_hugepage_size?\",\n        memory_prefault as \"memory_prefault!\",\n        memory_thp as \"memory_thp!\",\n        image_ref as \"image_ref?\",\n        cloud_init_user_data as \"cloud_init_user_data?\",\n        cloud_init_meta_data as \"cloud_init_meta_data?\",\n        cloud_init_network_config as \"cloud_init_network_config?\",\n        config as \"config: _\"\nFROM vms\nWHERE config->>'failed_over_from' = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "tags!",
+        "type_info": "TextArray"
+      },
+      {
+        "ordinal": 3,
+        "name": "status: _",
+        "type_info": {
+          "Custom": {
+            "name": "vm_status",
+            "kind": {
+              "Enum": [
+                "UNKNOWN",
+                "CREATED",
+                "RUNNING",
+                "PAUSED",
+                "SHUTDOWN",
+                "PENDING",
+                "MIGRATING",
+                "COMMITTING"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "host_id?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 5,
+        "name": "hypervisor: _",
+        "type_info": {
+          "Custom": {
+            "name": "hypervisor",
+            "kind": {
+              "Enum": [
+                "CLOUD_HV",
+                "FIRECRACKER",
+                "QEMU"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "boot_source_id?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 7,
+        "name": "boot_mode: _",
+        "type_info": {
+          "Custom": {
+            "name": "boot_mode",
+            "kind": {
+              "Enum": [
+                "KERNEL",
+                "FIRMWARE"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 8,
+        "name": "description?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "boot_vcpus",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "max_vcpus",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 11,
+        "name": "cpu_topology: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 12,
+        "name": "kvm_hyperv!",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "memory_size",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 14,
+        "name": "memory_hotplug_size?",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 15,
+        "name": "memory_mergeable!",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 16,
+        "name": "memory_shared!",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "memory_hugepages!",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 18,
+        "name": "memory_hugepage_size?",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 19,
+        "name": "memory_prefault!",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 20,
+        "name": "memory_thp!",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 21,
+        "name": "image_ref?",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 22,
+        "name": "cloud_init_user_data?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 23,
+        "name": "cloud_init_meta_data?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 24,
+        "name": "cloud_init_network_config?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 25,
+        "name": "config: _",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "5803cd6957856f8bbad1b62ec72c6bb7c8da4095972247f6b43dd182a71595b8"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ Do not jump to code investigation when services may not be running or the wrong 
 - `qarax/src/grpc_client.rs` — Tonic client for communicating with qarax-node instances
 - `qarax/src/vm_monitor.rs` — Background task that periodically reconciles VM status with nodes
 - `qarax/src/resource_monitor.rs` — Background task polling host resource metrics
+- `qarax/src/ha_monitor.rs` — Background task failing over HA-enabled VMs from dead hosts
 - `qarax/src/hook_executor.rs` — Background task managing lifecycle hook executions
 - `qarax/src/transfer_executor.rs` — Async file transfer handling
 - `qarax/src/host_deployer.rs` — Host deployment via SSH + bootc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.3"
+version = "0.7.0-rc.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+checksum = "96dacf199529fb801ae62a9aafdc01b189e9504c0d1ee1512a4c16bcd8666a93"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -990,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-primes"
-version = "0.7.0"
+version = "0.7.0-pre.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f41f23de7d24cdbda7f0c4d9c0351f99a4ceb258ef30e5c1927af8987ffe5a"
+checksum = "6081ce8b60c0e533e2bba42771b94eb6149052115f4179744d5779883dc98583"
 dependencies = [
  "crypto-bigint",
  "libm",
@@ -1272,7 +1272,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1312,16 +1312,16 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.17"
+version = "0.17.0-rc.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4bf51f0534ed6e59a0f2f26272b64ba55c470133f8424c2adfd1c4d59d9988"
+checksum = "91bbdd377139884fafcad8dc43a760a3e1e681aa26db910257fa6535b70e1829"
 dependencies = [
  "der 0.8.0",
  "digest 0.11.2",
  "elliptic-curve",
  "rfc6979",
  "signature 3.0.0-rc.10",
- "spki 0.8.0",
+ "spki 0.8.0-rc.4",
  "zeroize",
 ]
 
@@ -1381,9 +1381,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.31"
+version = "0.14.0-rc.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b148a81cede8f4023248f980cffdf7611c46f2add469c6980e815b7c5b764ba5"
+checksum = "bde7860544606d222fd6bd6d9f9a0773321bf78072a637e1d560a058c0031978"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -1436,7 +1436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2170,7 +2170,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2405,7 +2405,7 @@ dependencies = [
  "p384",
  "p521",
  "rand_core 0.10.1",
- "rsa 0.10.0-rc.17",
+ "rsa 0.10.0-rc.16",
  "sec1",
  "sha1 0.11.0",
  "sha2 0.11.0",
@@ -2826,9 +2826,9 @@ dependencies = [
 
 [[package]]
 name = "ml-kem"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04437cb1a66c0b78740927b76cc61f218344b9f6ef3dd430e283274a718ef0e9"
+checksum = "8198b5db27ac9773534c371751a59dc18aec8b80aa141e69abfdd1dec2e3f78c"
 dependencies = [
  "hybrid-array",
  "kem",
@@ -2970,7 +2970,17 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -3289,9 +3299,9 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b97e3bf0465157ae90975ff52dbeb1362ba618924878c9f74c25baa27a65f9a"
+checksum = "018bfbb86e05fd70a83e985921241035ee09fcd369c4a2c3680b389a01d2ad28"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -3302,9 +3312,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437f30ebcb1e16ff48acead5f08bd69fbcdbc82421687bb48af5c315a0bfab03"
+checksum = "8c91df688211f5957dbe2ab599dcbcaade8d6d3cdc15c5b350d350d7d07ce423"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -3316,9 +3326,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9fd792bab86ecf6249561752fb5a413511f999887107dd054bbda5143743d7"
+checksum = "de6cd9451de522549d36cc78a1b45a699a3d55a872e8ea0c8f0318e502d99e2c"
 dependencies = [
  "base16ct",
  "ecdsa",
@@ -3551,7 +3561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
 dependencies = [
  "der 0.8.0",
- "spki 0.8.0",
+ "spki 0.8.0-rc.4",
 ]
 
 [[package]]
@@ -3568,7 +3578,7 @@ dependencies = [
  "rand_core 0.10.1",
  "scrypt",
  "sha2 0.11.0",
- "spki 0.8.0",
+ "spki 0.8.0-rc.4",
 ]
 
 [[package]]
@@ -3590,7 +3600,7 @@ dependencies = [
  "der 0.8.0",
  "pkcs5",
  "rand_core 0.10.1",
- "spki 0.8.0",
+ "spki 0.8.0-rc.4",
 ]
 
 [[package]]
@@ -3675,9 +3685,9 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b52e6ee42db392378a95622b463c9740631171d1efce43fa445a569c1600cb6"
+checksum = "93401c13cc7ff24684571cfca9d3cf9ebabfaf3d4b7b9963ade41ec54da196b5"
 dependencies = [
  "crypto-bigint",
  "crypto-common 0.2.1",
@@ -3689,9 +3699,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0556580e42c19833f5d232aca11a7687a503ee41f937b54f5ae1d50fc2a6a36a"
+checksum = "a0c5c8a39bcd764bfedf456e8d55e115fe86dda3e0f555371849f2a41cbc9706"
 dependencies = [
  "elliptic-curve",
 ]
@@ -3778,7 +3788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -3947,7 +3957,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.39",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3985,9 +3995,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4346,9 +4356,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.10.0-rc.17"
+version = "0.10.0-rc.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ed3e93fc7e473e464b9726f4759659e72bc8665e4b8ea227547024f416d905"
+checksum = "6fb9fd8c1edd9e6a2693623baf0fe77ff05ce022a5d7746900ffc38a15c233de"
 dependencies = [
  "const-oid 0.10.2",
  "crypto-bigint",
@@ -4359,7 +4369,7 @@ dependencies = [
  "rand_core 0.10.1",
  "sha2 0.11.0",
  "signature 3.0.0-rc.10",
- "spki 0.8.0",
+ "spki 0.8.0-rc.4",
  "zeroize",
 ]
 
@@ -4383,19 +4393,24 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.60.1"
+version = "0.60.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d937f3f4a79bffd67fc12fd437785effdfc8b94edc89ab90392f9ac9e11cc9fc"
+checksum = "324b92f459d3e42da294e14e8eb150d2215fcfb7c966838bc1127cd68bc05a0d"
 dependencies = [
+ "aead 0.6.0-rc.10",
  "aes 0.8.4",
+ "aes 0.9.0",
+ "aes-gcm 0.11.0-rc.3",
  "aws-lc-rs",
  "bitflags 2.11.1",
  "block-padding 0.3.3",
  "byteorder",
  "bytes",
  "cbc 0.1.2",
+ "cbc 0.2.0",
  "cipher 0.5.1",
  "crypto-bigint",
+ "ctr 0.10.0",
  "ctr 0.9.2",
  "curve25519-dalek",
  "data-encoding",
@@ -4410,34 +4425,45 @@ dependencies = [
  "futures",
  "generic-array 1.3.5",
  "getrandom 0.2.17",
+ "ghash 0.6.0",
  "hex-literal",
+ "hkdf 0.13.0",
  "hmac 0.12.1",
+ "hmac 0.13.0",
  "inout 0.1.4",
  "internal-russh-forked-ssh-key",
  "internal-russh-num-bigint",
+ "keccak",
  "log",
  "md5",
  "ml-kem",
  "module-lattice",
+ "num-bigint",
  "p256",
  "p384",
  "p521",
  "pageant",
  "pbkdf2 0.12.2",
+ "pbkdf2 0.13.0",
  "pkcs1 0.8.0-rc.4",
  "pkcs5",
  "pkcs8 0.11.0-rc.11",
  "polyval 0.7.1",
  "rand 0.10.1",
  "rand_core 0.10.1",
- "rsa 0.10.0-rc.17",
+ "rsa 0.10.0-rc.16",
  "russh-cryptovec",
  "russh-util",
+ "salsa20",
+ "scrypt",
  "sec1",
  "sha1 0.10.6",
+ "sha1 0.11.0",
  "sha2 0.10.9",
+ "sha2 0.11.0",
+ "sha3",
  "signature 3.0.0-rc.10",
- "spki 0.8.0",
+ "spki 0.8.0-rc.4",
  "ssh-encoding",
  "subtle",
  "thiserror 2.0.18",
@@ -4449,9 +4475,9 @@ dependencies = [
 
 [[package]]
 name = "russh-cryptovec"
-version = "0.59.0"
+version = "0.60.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36140e8a20297bc2e8338807c3d9ca911f7fa49d7539cbcd6d48d3befd70efd8"
+checksum = "37cb4d0360bdd8935392a306d8b5edb539cc455b30e8bf13dd213a0cf7879b40"
 dependencies = [
  "log",
  "nix 0.31.2",
@@ -4586,7 +4612,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4665,7 +4691,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5158,9 +5184,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.8.0"
+version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
 dependencies = [
  "base64ct",
  "der 0.8.0",
@@ -5576,7 +5602,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6666,7 +6692,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6814,15 +6840,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6869,28 +6886,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6921,12 +6921,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6943,12 +6937,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6969,22 +6957,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7005,12 +6981,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7027,12 +6997,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7053,12 +7017,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7075,12 +7033,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/TODO.md
+++ b/TODO.md
@@ -51,7 +51,10 @@ Platform
 
   - Web UI — full management interface with console, graphs, VM lifecycle
   - RBAC / Auth — users, groups, roles, LDAP, API tokens, 2FA
-  - High Availability — automatic failover, fencing, cluster config replication
+  - High Availability — automatic failover DONE (ha_enabled VMs restart on
+    another host when theirs dies). Remaining: real fencing (IPMI/watchdog/
+    storage lease — currently timeout + re-probe based), cluster config
+    replication, failover for GPU and local-disk VMs
   - Audit log — record all API mutations with actor and before/after state
   - Resource pools — group VMs/hosts for delegation, billing, quotas
   - Scheduled backups — cron-based snapshot scheduling with retention policies

--- a/cli/src/api/models.rs
+++ b/cli/src/api/models.rs
@@ -19,6 +19,8 @@ pub struct Vm {
     pub description: Option<String>,
     pub placement_policy: Option<serde_json::Value>,
     pub guest_agent: bool,
+    #[serde(default)]
+    pub ha_enabled: bool,
     pub boot_vcpus: i32,
     pub max_vcpus: i32,
     pub memory_size: i64,
@@ -93,6 +95,8 @@ pub struct NewVm {
     pub placement_policy: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guest_agent: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ha_enabled: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/cli/src/commands/vm.rs
+++ b/cli/src/commands/vm.rs
@@ -119,6 +119,10 @@ enum VmCommand {
         /// Enable the guest agent used by `qarax vm exec`
         #[arg(long)]
         guest_agent: bool,
+        /// Enable high availability: restart the VM on another host if its
+        /// host fails. Requires all VM disks to be on shared storage pools.
+        #[arg(long)]
+        ha: bool,
         /// Number of GPUs to request (enables GPU-aware scheduling)
         #[arg(long)]
         gpu_count: Option<i32>,
@@ -513,6 +517,10 @@ pub async fn run(args: VmArgs, client: &Client, output: OutputFormat) -> anyhow:
                         "disabled"
                     }
                 );
+                println!(
+                    "HA:          {}",
+                    if vm.ha_enabled { "enabled" } else { "disabled" }
+                );
                 println!("Boot mode:   {}", vm.boot_mode);
                 println!("vCPUs:       {}/{}", vm.boot_vcpus, vm.max_vcpus);
                 println!("Memory:      {}", format_bytes(vm.memory_size));
@@ -561,6 +569,7 @@ pub async fn run(args: VmArgs, client: &Client, output: OutputFormat) -> anyhow:
             cloud_init_meta_data,
             cloud_init_network_config,
             guest_agent,
+            ha,
             gpu_count,
             gpu_vendor,
             gpu_model,
@@ -699,6 +708,7 @@ pub async fn run(args: VmArgs, client: &Client, output: OutputFormat) -> anyhow:
                 persistent_upper_pool_id,
                 placement_policy,
                 guest_agent: guest_agent.then_some(true),
+                ha_enabled: ha.then_some(true),
             };
 
             let result = api::vms::create(client, &new_vm).await?;

--- a/configuration/base.yaml
+++ b/configuration/base.yaml
@@ -17,6 +17,11 @@ scheduling:
   cpu_oversubscription_ratio: 4.0
   disk_headroom_bytes: 10737418240
   memory_health_floor_bytes: 1073741824
+ha:
+  enabled: true
+  failover_grace_seconds: 60
+  check_interval_seconds: 15
+  retry_cooldown_seconds: 120
 telemetry:
   otel_enabled: false
   otlp_endpoint: "http://localhost:4318"

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -101,6 +101,9 @@ services:
       VM_FIRMWARE: ${VM_FIRMWARE:-/usr/share/cloud-hypervisor/CLOUDHV.fd}
       # Reduce disk headroom for CI — runners have limited free disk
       SCHEDULING_DISK_HEADROOM_BYTES: ${SCHEDULING_DISK_HEADROOM_BYTES:-1073741824}
+      # Short HA windows so the failover e2e test completes quickly
+      HA_FAILOVER_GRACE_SECONDS: ${HA_FAILOVER_GRACE_SECONDS:-5}
+      HA_CHECK_INTERVAL_SECONDS: ${HA_CHECK_INTERVAL_SECONDS:-5}
     ports:
       - "8000:8000"
     depends_on:

--- a/e2e/test_ha_failover.py
+++ b/e2e/test_ha_failover.py
@@ -242,14 +242,14 @@ async def test_ha_failover_on_host_failure(client, two_hosts):
             stopped_service = node_service_by_host[host1_id]
             _compose("stop", stopped_service)
 
+            # The dead host must be marked DOWN before failover can start.
+            await _wait_for_host_status(c, dead_host_id, HostStatus.DOWN, timeout=30)
+
             # The HA VM must come back RUNNING on the surviving host.
             vm = await _wait_for_failover(c, ha_vm_id, dead_host_id)
             assert vm.host_id == host2_id, (
                 f"Expected HA VM on host2 after failover, got {vm.host_id}"
             )
-
-            # The dead host must be marked DOWN.
-            await _wait_for_host_status(c, dead_host_id, HostStatus.DOWN, timeout=30)
 
             # The non-HA VM must not have been rescheduled.
             plain_vm = await get_vm.asyncio(client=c, vm_id=plain_vm_id)

--- a/e2e/test_ha_failover.py
+++ b/e2e/test_ha_failover.py
@@ -1,0 +1,284 @@
+"""
+E2E tests for automatic HA failover.
+
+These tests verify that when a host dies, VMs created with ha_enabled are
+automatically restarted on another host, while non-HA VMs stay put:
+- Both VMs are pinned to one host (the other is put in maintenance during
+  creation), then that host's qarax-node container is stopped.
+- The control plane marks the host DOWN, and after the HA grace period
+  (HA_FAILOVER_GRACE_SECONDS, set low in docker-compose.yml) the HA monitor
+  cold-restarts the HA VM on the surviving host.
+- The non-HA VM must not be rescheduled.
+
+Prerequisites (provided by docker-compose.yml):
+- Two qarax-node instances: qarax-node (host1) and qarax-node-2 (host2)
+- HA_FAILOVER_GRACE_SECONDS / HA_CHECK_INTERVAL_SECONDS set to a few seconds
+
+The test manipulates the docker compose stack (stop/start of a node
+service), so it must run against the standard e2e compose project.
+"""
+
+import asyncio
+import os
+import subprocess
+import time
+import uuid
+from pathlib import Path
+from uuid import UUID
+
+import httpx
+import pytest
+from qarax_api_client import Client
+from qarax_api_client.api.hosts import add as add_host
+from qarax_api_client.api.hosts import init as init_host
+from qarax_api_client.api.hosts import list_ as list_hosts
+from qarax_api_client.api.hosts import update as update_host
+from qarax_api_client.api.vms import delete as delete_vm
+from qarax_api_client.api.vms import get as get_vm
+from qarax_api_client.api.vms import start as start_vm
+from qarax_api_client.api.vms import stop as stop_vm
+from qarax_api_client.models import HostStatus, UpdateHostRequest
+from qarax_api_client.models.new_host import NewHost
+from qarax_api_client.models.vm_status import VmStatus
+
+QARAX_URL = os.getenv("QARAX_URL", "http://localhost:8000")
+QARAX_NODE_HOST = os.getenv("QARAX_NODE_HOST", "qarax-node")
+QARAX_NODE_PORT = int(os.getenv("QARAX_NODE_PORT", "50051"))
+QARAX_NODE_2_HOST = os.getenv("QARAX_NODE_2_HOST", "qarax-node-2")
+QARAX_NODE_2_PORT = int(os.getenv("QARAX_NODE_2_PORT", "50051"))
+
+E2E_DIR = Path(__file__).parent
+
+VM_OPERATION_TIMEOUT = 60
+# Host-down detection (resource monitor tick, 30s) + HA grace + HA tick + boot
+FAILOVER_TIMEOUT = 180
+
+
+@pytest.fixture
+def client():
+    return Client(base_url=QARAX_URL)
+
+
+def _register_and_init_host(client, address, port, name):
+    """Register a host if not already present and initialize it. Returns host_id."""
+    hosts = list_hosts.sync(client=client)
+    if hosts is None:
+        raise RuntimeError("Failed to list hosts")
+
+    existing = next((h for h in hosts if h.address == address), None)
+    if existing is not None:
+        host_id = existing.id
+    else:
+        new_host = NewHost(
+            name=name, address=address, port=port, host_user="root", password=""
+        )
+        result = add_host.sync_detailed(client=client, body=new_host)
+        if result.status_code.value == 201:
+            host_id = UUID(result.parsed.strip())
+        else:
+            hosts = list_hosts.sync(client=client)
+            existing = next((h for h in hosts if h.address == address), None)
+            if existing is None:
+                raise RuntimeError(f"Could not register host at {address}:{port}")
+            host_id = existing.id
+
+    result = init_host.sync_detailed(host_id=host_id, client=client)
+    if result.status_code.value != 200:
+        raise RuntimeError(
+            f"Failed to initialize host {host_id}: HTTP {result.status_code}"
+        )
+    return host_id
+
+
+@pytest.fixture(scope="module")
+def two_hosts():
+    """Ensure both qarax-node instances are registered and initialized. Returns (host1_id, host2_id)."""
+    c = Client(base_url=QARAX_URL)
+    host1_id = _register_and_init_host(
+        c, QARAX_NODE_HOST, QARAX_NODE_PORT, "e2e-node-1"
+    )
+    host2_id = _register_and_init_host(
+        c, QARAX_NODE_2_HOST, QARAX_NODE_2_PORT, "e2e-node-2"
+    )
+    return host1_id, host2_id
+
+
+def _compose(*args):
+    subprocess.run(
+        ["docker", "compose", *args],
+        cwd=E2E_DIR,
+        check=True,
+        capture_output=True,
+    )
+
+
+async def _wait_for_vm_status(c, vm_id, expected_status, timeout=VM_OPERATION_TIMEOUT):
+    start = time.time()
+    while time.time() - start < timeout:
+        vm = await get_vm.asyncio(client=c, vm_id=vm_id)
+        if vm.status == expected_status:
+            return vm
+        await asyncio.sleep(0.5)
+    vm = await get_vm.asyncio(client=c, vm_id=vm_id)
+    raise TimeoutError(
+        f"VM {vm_id} did not reach {expected_status} within {timeout}s. Current: {vm.status}"
+    )
+
+
+async def _wait_for_host_status(c, host_id, expected_status, timeout=120):
+    start = time.time()
+    while time.time() - start < timeout:
+        hosts = await list_hosts.asyncio(client=c)
+        host = next((h for h in hosts or [] if h.id == host_id), None)
+        if host is not None and host.status == expected_status:
+            return host
+        await asyncio.sleep(1)
+    raise TimeoutError(f"Host {host_id} did not reach {expected_status} within {timeout}s")
+
+
+async def _wait_for_failover(c, vm_id, source_host_id, timeout=FAILOVER_TIMEOUT):
+    """Wait until the VM is RUNNING on a host other than source_host_id."""
+    start = time.time()
+    while time.time() - start < timeout:
+        vm = await get_vm.asyncio(client=c, vm_id=vm_id)
+        if vm.status == VmStatus.RUNNING and vm.host_id != source_host_id:
+            return vm
+        await asyncio.sleep(2)
+    vm = await get_vm.asyncio(client=c, vm_id=vm_id)
+    raise TimeoutError(
+        f"VM {vm_id} did not fail over within {timeout}s. "
+        f"Current: status={vm.status} host_id={vm.host_id}"
+    )
+
+
+async def _create_vm_raw(http_client, *, name, ha_enabled):
+    resp = await http_client.post(
+        "/vms",
+        json={
+            "name": name,
+            "hypervisor": "cloud_hv",
+            "boot_vcpus": 1,
+            "max_vcpus": 1,
+            "memory_size": 256 * 1024 * 1024,
+            "ha_enabled": ha_enabled,
+        },
+    )
+    assert resp.status_code == 201, (
+        f"Failed to create VM {name}: HTTP {resp.status_code} {resp.text}"
+    )
+    return UUID(resp.text.strip('"'))
+
+
+@pytest.mark.asyncio
+async def test_ha_enabled_is_persisted(client, two_hosts):
+    """ha_enabled survives the round trip through create and get."""
+    async with httpx.AsyncClient(base_url=QARAX_URL) as http_client:
+        vm_id = await _create_vm_raw(
+            http_client, name=f"e2e-ha-flag-{uuid.uuid4().hex[:6]}", ha_enabled=True
+        )
+        try:
+            resp = await http_client.get(f"/vms/{vm_id}")
+            assert resp.status_code == 200
+            assert resp.json()["ha_enabled"] is True
+        finally:
+            await http_client.delete(f"/vms/{vm_id}")
+
+
+@pytest.mark.asyncio
+async def test_ha_failover_on_host_failure(client, two_hosts):
+    """
+    Full HA failover lifecycle:
+    - Pin one HA VM and one non-HA VM to host A (host B in maintenance)
+    - Stop host A's qarax-node container
+    - Assert the HA VM is restarted RUNNING on host B
+    - Assert the non-HA VM is not rescheduled
+    """
+    host1_id, host2_id = two_hosts
+    node_service_by_host = {host1_id: "qarax-node", host2_id: "qarax-node-2"}
+
+    ha_vm_id = None
+    plain_vm_id = None
+    dead_host_id = None
+    stopped_service = None
+
+    async with client as c, httpx.AsyncClient(base_url=QARAX_URL) as http_client:
+        try:
+            # Pin both VMs to host1 by putting host2 in maintenance.
+            await update_host.asyncio_detailed(
+                client=c,
+                host_id=host2_id,
+                body=UpdateHostRequest(status=HostStatus.MAINTENANCE),
+            )
+            await _wait_for_host_status(c, host2_id, HostStatus.MAINTENANCE)
+
+            ha_vm_id = await _create_vm_raw(
+                http_client,
+                name=f"e2e-ha-failover-{uuid.uuid4().hex[:6]}",
+                ha_enabled=True,
+            )
+            plain_vm_id = await _create_vm_raw(
+                http_client,
+                name=f"e2e-ha-plain-{uuid.uuid4().hex[:6]}",
+                ha_enabled=False,
+            )
+
+            for vm_id in (ha_vm_id, plain_vm_id):
+                await start_vm.asyncio_detailed(client=c, vm_id=vm_id)
+                vm = await _wait_for_vm_status(c, vm_id, VmStatus.RUNNING)
+                assert vm.host_id == host1_id, (
+                    f"VM {vm_id} should be pinned to host1, got {vm.host_id}"
+                )
+
+            # Make host2 schedulable again so failover has a destination.
+            await update_host.asyncio_detailed(
+                client=c,
+                host_id=host2_id,
+                body=UpdateHostRequest(status=HostStatus.UP),
+            )
+            await _wait_for_host_status(c, host2_id, HostStatus.UP)
+
+            # Kill host1's node.
+            dead_host_id = host1_id
+            stopped_service = node_service_by_host[host1_id]
+            _compose("stop", stopped_service)
+
+            # The HA VM must come back RUNNING on the surviving host.
+            vm = await _wait_for_failover(c, ha_vm_id, dead_host_id)
+            assert vm.host_id == host2_id, (
+                f"Expected HA VM on host2 after failover, got {vm.host_id}"
+            )
+
+            # The dead host must be marked DOWN.
+            await _wait_for_host_status(c, dead_host_id, HostStatus.DOWN, timeout=30)
+
+            # The non-HA VM must not have been rescheduled.
+            plain_vm = await get_vm.asyncio(client=c, vm_id=plain_vm_id)
+            assert plain_vm.host_id == dead_host_id, (
+                "non-HA VM should not be failed over"
+            )
+
+            await stop_vm.asyncio_detailed(client=c, vm_id=ha_vm_id)
+        finally:
+            if stopped_service is not None:
+                _compose("start", stopped_service)
+                # Give the recovered node time to become reachable so the HA
+                # monitor can clean up stale copies and deletes can route.
+                await asyncio.sleep(10)
+            if dead_host_id is not None:
+                await update_host.asyncio_detailed(
+                    host_id=dead_host_id,
+                    client=c,
+                    body=UpdateHostRequest(status=HostStatus.UP),
+                )
+                await _wait_for_host_status(c, dead_host_id, HostStatus.UP)
+            for vm_id in (ha_vm_id, plain_vm_id):
+                if vm_id is None:
+                    continue
+                try:
+                    await stop_vm.asyncio_detailed(client=c, vm_id=vm_id)
+                except Exception:
+                    pass
+                try:
+                    await delete_vm.asyncio_detailed(client=c, vm_id=vm_id)
+                except Exception:
+                    pass

--- a/migrations/20260611000001_vm_failover_job_type.sql
+++ b/migrations/20260611000001_vm_failover_job_type.sql
@@ -1,0 +1,2 @@
+-- Job type for automatic HA failover of VMs from failed hosts.
+ALTER TYPE job_type ADD VALUE IF NOT EXISTS 'VM_FAILOVER';

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3795,6 +3795,7 @@ components:
       - sandbox_claim
       - vm_start
       - vm_migrate
+      - vm_failover
       - host_evacuate
       - disk_create
       - vm_commit
@@ -4304,6 +4305,14 @@ components:
           - boolean
           - 'null'
           description: Enable the guest agent used by `vm exec`.
+        ha_enabled:
+          type:
+          - boolean
+          - 'null'
+          description: |-
+            Enable high availability for this VM. When its host fails, the VM is
+            automatically restarted on another eligible host. Requires all disks
+            to live on shared storage pools.
         hypervisor:
           oneOf:
           - type: 'null'
@@ -5183,6 +5192,7 @@ components:
       - hypervisor
       - boot_mode
       - guest_agent
+      - ha_enabled
       - boot_vcpus
       - max_vcpus
       - kvm_hyperv
@@ -5223,6 +5233,8 @@ components:
           - string
           - 'null'
         guest_agent:
+          type: boolean
+        ha_enabled:
           type: boolean
         host_id:
           type:

--- a/python-sdk/qarax-api-client/qarax_api_client/models/job_type.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/models/job_type.py
@@ -7,6 +7,7 @@ class JobType(str, Enum):
     IMAGE_PULL = "image_pull"
     SANDBOX_CLAIM = "sandbox_claim"
     VM_COMMIT = "vm_commit"
+    VM_FAILOVER = "vm_failover"
     VM_MIGRATE = "vm_migrate"
     VM_START = "vm_start"
 

--- a/python-sdk/qarax-api-client/qarax_api_client/models/new_vm.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/models/new_vm.py
@@ -42,6 +42,9 @@ class NewVm:
         cpu_topology (Any | Unset):
         description (None | str | Unset):
         guest_agent (bool | None | Unset): Enable the guest agent used by `vm exec`.
+        ha_enabled (bool | None | Unset): Enable high availability for this VM. When its host fails, the VM is
+            automatically restarted on another eligible host. Requires all disks
+            to live on shared storage pools.
         hypervisor (Hypervisor | None | Unset):
         image_ref (None | str | Unset): OCI image reference to use as root filesystem (e.g.
             "docker.io/library/ubuntu:22.04").
@@ -91,6 +94,7 @@ class NewVm:
     cpu_topology: Any | Unset = UNSET
     description: None | str | Unset = UNSET
     guest_agent: bool | None | Unset = UNSET
+    ha_enabled: bool | None | Unset = UNSET
     hypervisor: Hypervisor | None | Unset = UNSET
     image_ref: None | str | Unset = UNSET
     instance_type_id: None | Unset | UUID = UNSET
@@ -183,6 +187,12 @@ class NewVm:
             guest_agent = UNSET
         else:
             guest_agent = self.guest_agent
+
+        ha_enabled: bool | None | Unset
+        if isinstance(self.ha_enabled, Unset):
+            ha_enabled = UNSET
+        else:
+            ha_enabled = self.ha_enabled
 
         hypervisor: None | str | Unset
         if isinstance(self.hypervisor, Unset):
@@ -369,6 +379,8 @@ class NewVm:
             field_dict["description"] = description
         if guest_agent is not UNSET:
             field_dict["guest_agent"] = guest_agent
+        if ha_enabled is not UNSET:
+            field_dict["ha_enabled"] = ha_enabled
         if hypervisor is not UNSET:
             field_dict["hypervisor"] = hypervisor
         if image_ref is not UNSET:
@@ -526,6 +538,15 @@ class NewVm:
             return cast(bool | None | Unset, data)
 
         guest_agent = _parse_guest_agent(d.pop("guest_agent", UNSET))
+
+        def _parse_ha_enabled(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        ha_enabled = _parse_ha_enabled(d.pop("ha_enabled", UNSET))
 
         def _parse_hypervisor(data: object) -> Hypervisor | None | Unset:
             if data is None:
@@ -817,6 +838,7 @@ class NewVm:
             cpu_topology=cpu_topology,
             description=description,
             guest_agent=guest_agent,
+            ha_enabled=ha_enabled,
             hypervisor=hypervisor,
             image_ref=image_ref,
             instance_type_id=instance_type_id,

--- a/python-sdk/qarax-api-client/qarax_api_client/models/vm.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/models/vm.py
@@ -26,6 +26,7 @@ class Vm:
         boot_vcpus (int):
         config (Any):
         guest_agent (bool):
+        ha_enabled (bool):
         hypervisor (Hypervisor):
         id (UUID):
         kvm_hyperv (bool):
@@ -56,6 +57,7 @@ class Vm:
     boot_vcpus: int
     config: Any
     guest_agent: bool
+    ha_enabled: bool
     hypervisor: Hypervisor
     id: UUID
     kvm_hyperv: bool
@@ -92,6 +94,8 @@ class Vm:
         config = self.config
 
         guest_agent = self.guest_agent
+
+        ha_enabled = self.ha_enabled
 
         hypervisor = self.hypervisor.value
 
@@ -195,6 +199,7 @@ class Vm:
                 "boot_vcpus": boot_vcpus,
                 "config": config,
                 "guest_agent": guest_agent,
+                "ha_enabled": ha_enabled,
                 "hypervisor": hypervisor,
                 "id": id,
                 "kvm_hyperv": kvm_hyperv,
@@ -247,6 +252,8 @@ class Vm:
         config = d.pop("config")
 
         guest_agent = d.pop("guest_agent")
+
+        ha_enabled = d.pop("ha_enabled")
 
         hypervisor = Hypervisor(d.pop("hypervisor"))
 
@@ -395,6 +402,7 @@ class Vm:
             boot_vcpus=boot_vcpus,
             config=config,
             guest_agent=guest_agent,
+            ha_enabled=ha_enabled,
             hypervisor=hypervisor,
             id=id,
             kvm_hyperv=kvm_hyperv,

--- a/qarax/Cargo.toml
+++ b/qarax/Cargo.toml
@@ -49,7 +49,7 @@ sha2 = "0.10"
 hex = "0.4"
 tonic = "0.10.2"
 prost = "0.12.3"
-russh = "0.60.1"
+russh = "0.60.3"
 # russh 0.60.x pulls pkcs8-0.11.0-rc.11 which requires pkcs5 0.8.0-rc.13; pin to
 # prevent Cargo from upgrading to pkcs5 0.8.0 stable where ::recommended was renamed.
 pkcs5 = "=0.8.0-rc.13"

--- a/qarax/src/configuration.rs
+++ b/qarax/src/configuration.rs
@@ -51,6 +51,52 @@ fn default_memory_health_floor_bytes() -> i64 {
 }
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
+pub struct HaSettings {
+    /// Master switch for the HA failover monitor.
+    #[serde(default = "default_ha_enabled")]
+    pub enabled: bool,
+    /// How long a host must stay down and unreachable before its HA VMs are
+    /// failed over. Acts as the split-brain guard: keep it comfortably above
+    /// transient network-blip duration.
+    #[serde(default = "default_ha_failover_grace_seconds")]
+    pub failover_grace_seconds: u64,
+    /// How often the HA monitor re-probes down hosts.
+    #[serde(default = "default_ha_check_interval_seconds")]
+    pub check_interval_seconds: u64,
+    /// Minimum delay between failover attempts for the same VM (e.g. while
+    /// waiting for capacity to free up).
+    #[serde(default = "default_ha_retry_cooldown_seconds")]
+    pub retry_cooldown_seconds: u64,
+}
+
+impl Default for HaSettings {
+    fn default() -> Self {
+        Self {
+            enabled: default_ha_enabled(),
+            failover_grace_seconds: default_ha_failover_grace_seconds(),
+            check_interval_seconds: default_ha_check_interval_seconds(),
+            retry_cooldown_seconds: default_ha_retry_cooldown_seconds(),
+        }
+    }
+}
+
+fn default_ha_enabled() -> bool {
+    true
+}
+
+fn default_ha_failover_grace_seconds() -> u64 {
+    60
+}
+
+fn default_ha_check_interval_seconds() -> u64 {
+    15
+}
+
+fn default_ha_retry_cooldown_seconds() -> u64 {
+    120
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
 pub struct SandboxSettings {
     #[serde(default = "default_sandbox_idle_timeout_secs")]
     pub default_idle_timeout_secs: i32,
@@ -155,6 +201,8 @@ pub struct Settings {
     pub scheduling: SchedulingSettings,
     #[serde(default)]
     pub sandbox: SandboxSettings,
+    #[serde(default)]
+    pub ha: HaSettings,
     #[serde(default)]
     pub telemetry: TelemetrySettings,
 }
@@ -261,6 +309,23 @@ pub fn get_configuration() -> Result<Settings, config::ConfigError> {
         .set_override_option(
             "scheduling.memory_health_floor_bytes",
             std::env::var("SCHEDULING_MEMORY_HEALTH_FLOOR_BYTES")
+                .ok()
+                .filter(|s| !s.is_empty()),
+        )?
+        // Override HA settings from environment variables if set and non-empty
+        .set_override_option(
+            "ha.enabled",
+            std::env::var("HA_ENABLED").ok().filter(|s| !s.is_empty()),
+        )?
+        .set_override_option(
+            "ha.failover_grace_seconds",
+            std::env::var("HA_FAILOVER_GRACE_SECONDS")
+                .ok()
+                .filter(|s| !s.is_empty()),
+        )?
+        .set_override_option(
+            "ha.check_interval_seconds",
+            std::env::var("HA_CHECK_INTERVAL_SECONDS")
                 .ok()
                 .filter(|s| !s.is_empty()),
         )?

--- a/qarax/src/ha_monitor.rs
+++ b/qarax/src/ha_monitor.rs
@@ -1,0 +1,623 @@
+/// Background task that automatically fails over HA-enabled VMs from failed
+/// hosts.
+///
+/// The resource monitor marks hosts `Down` when probes fail. This monitor
+/// re-probes those hosts on every tick and, once a host has stayed
+/// unreachable for at least `ha.failover_grace_seconds`, cold-restarts its
+/// resident VMs that have `ha_enabled` on another eligible host via the
+/// regular scheduling path.
+///
+/// Split-brain guards (a VM must never run twice against shared storage):
+/// - failover only happens after the grace period *and* a fresh probe failure
+///   immediately before acting,
+/// - only VMs whose disks all live on shared pools are eligible,
+/// - failed-over VMs are tagged with `failed_over_from` in their config; if
+///   the source host ever becomes reachable again while still marked Down,
+///   the stale copies are force-stopped and deleted before anything else.
+use std::collections::{HashMap, HashSet};
+
+use tokio::time::{Duration, Instant, interval_at};
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use crate::App;
+use crate::configuration::HaSettings;
+use crate::errors::Error;
+use crate::grpc_client::NodeClient;
+use crate::handlers::host::handler::evacuation_scheduling_request;
+use crate::handlers::vm::handler::start_vm_internal;
+use crate::model::{
+    host_gpus,
+    hosts::{self, Host},
+    jobs::{self, JobType, NewJob},
+    storage_objects, storage_pools, vm_disks,
+    vms::{self, Vm, VmStatus},
+};
+
+#[derive(Default)]
+struct MonitorState {
+    /// When the monitor itself first confirmed each down host unreachable.
+    unreachable_since: HashMap<Uuid, Instant>,
+    /// Last failover attempt per VM, for retry cooldown.
+    last_attempt: HashMap<Uuid, Instant>,
+}
+
+pub async fn start_ha_monitor(env: App, settings: HaSettings) {
+    if !settings.enabled {
+        info!("HA monitor: disabled by configuration");
+        return;
+    }
+
+    let period = Duration::from_secs(settings.check_interval_seconds.max(1));
+    let mut ticker = interval_at(Instant::now() + period, period);
+    let mut state = MonitorState::default();
+
+    loop {
+        ticker.tick().await;
+
+        if env.maintenance_mode() {
+            continue;
+        }
+
+        #[cfg(feature = "otel")]
+        let _cycle_start = std::time::Instant::now();
+
+        run_cycle(&env, &settings, &mut state).await;
+
+        #[cfg(feature = "otel")]
+        crate::vm_monitor::record_monitor_cycle("ha", _cycle_start);
+    }
+}
+
+async fn run_cycle(env: &App, settings: &HaSettings, state: &mut MonitorState) {
+    let down_hosts = match hosts::list_down(env.pool()).await {
+        Ok(hosts) => hosts,
+        Err(e) => {
+            warn!("HA monitor: failed to list down hosts: {}", e);
+            return;
+        }
+    };
+
+    let down_ids: HashSet<Uuid> = down_hosts.iter().map(|h| h.id).collect();
+    state
+        .unreachable_since
+        .retain(|host_id, _| down_ids.contains(host_id));
+
+    for host in down_hosts {
+        let client = NodeClient::new(&host.address, host.port as u16);
+        if client.get_node_info().await.is_ok() {
+            // The host is reachable despite being marked Down (e.g. it
+            // recovered before an operator re-enabled it). Never fail over
+            // from a live host; instead remove stale copies of VMs that were
+            // already failed over from it.
+            state.unreachable_since.remove(&host.id);
+            cleanup_stale_copies(env, &host).await;
+            continue;
+        }
+
+        let first_unreachable = *state
+            .unreachable_since
+            .entry(host.id)
+            .or_insert_with(Instant::now);
+        if first_unreachable.elapsed() < Duration::from_secs(settings.failover_grace_seconds) {
+            continue;
+        }
+
+        failover_host(env, settings, state, &host).await;
+    }
+}
+
+/// Remove leftover VM processes on a recovered host for VMs that were failed
+/// over to another host, then clear their `failed_over_from` marker.
+async fn cleanup_stale_copies(env: &App, host: &Host) {
+    let stale_vms = match vms::list_failed_over_from(env.pool(), host.id).await {
+        Ok(vms) => vms,
+        Err(e) => {
+            warn!(
+                "HA monitor: failed to list failed-over VMs for host {}: {}",
+                host.name, e
+            );
+            return;
+        }
+    };
+
+    if stale_vms.is_empty() {
+        return;
+    }
+
+    let client = NodeClient::new(&host.address, host.port as u16);
+    for vm in stale_vms {
+        let _ = client.force_stop_vm(vm.id).await;
+        if let Err(e) = client.delete_vm(vm.id).await {
+            let not_found = e
+                .downcast_ref::<Error>()
+                .map(|e| matches!(e, Error::NotFound))
+                .unwrap_or(false);
+            if !not_found {
+                warn!(
+                    "HA monitor: failed to delete stale copy of VM {} on host {}: {}",
+                    vm.id, host.name, e
+                );
+                continue;
+            }
+        }
+
+        info!(
+            "HA monitor: removed stale copy of VM {} from recovered host {}",
+            vm.id, host.name
+        );
+        let mut config = vm.config.clone();
+        vms::set_failed_over_from(&mut config, None);
+        if let Err(e) = vms::update_config(env.pool(), vm.id, &config).await {
+            warn!(
+                "HA monitor: failed to clear failed_over_from for VM {}: {}",
+                vm.id, e
+            );
+        }
+    }
+}
+
+/// VMs on the given host that are eligible for automatic failover.
+async fn collect_failover_candidates(env: &App, host_id: Uuid) -> Result<Vec<Vm>, sqlx::Error> {
+    let resident = vms::list_by_host(env.pool(), host_id).await?;
+    Ok(resident
+        .into_iter()
+        .filter(|vm| {
+            vm.ha_enabled
+                && matches!(
+                    vm.status,
+                    VmStatus::Running | VmStatus::Paused | VmStatus::Unknown
+                )
+        })
+        .collect())
+}
+
+async fn failover_host(env: &App, settings: &HaSettings, state: &mut MonitorState, host: &Host) {
+    let candidates = match collect_failover_candidates(env, host.id).await {
+        Ok(vms) => vms,
+        Err(e) => {
+            warn!(
+                "HA monitor: failed to list resident VMs for host {}: {}",
+                host.name, e
+            );
+            return;
+        }
+    };
+
+    let cooldown = Duration::from_secs(settings.retry_cooldown_seconds);
+    for vm in candidates {
+        if state
+            .last_attempt
+            .get(&vm.id)
+            .is_some_and(|attempted| attempted.elapsed() < cooldown)
+        {
+            continue;
+        }
+        state.last_attempt.insert(vm.id, Instant::now());
+        failover_vm(env, &vm, host).await;
+    }
+}
+
+async fn failover_vm(env: &App, vm: &Vm, dead_host: &Host) {
+    info!(
+        "HA monitor: failing over VM {} ({}) from dead host {} ({})",
+        vm.name, vm.id, dead_host.name, dead_host.id
+    );
+
+    let job = match jobs::create(
+        env.pool(),
+        NewJob {
+            job_type: JobType::VmFailover,
+            description: Some(format!(
+                "Failing over VM {} from host {}",
+                vm.name, dead_host.name
+            )),
+            resource_id: Some(vm.id),
+            resource_type: Some(jobs::resource_types::VM.to_string()),
+        },
+    )
+    .await
+    {
+        Ok(job) => job,
+        Err(e) => {
+            warn!(
+                "HA monitor: failed to create failover job for VM {}: {}",
+                vm.id, e
+            );
+            return;
+        }
+    };
+
+    if let Err(e) = jobs::mark_running(env.pool(), job.id).await {
+        warn!(
+            "HA monitor: failed to mark failover job {} as running: {}",
+            job.id, e
+        );
+    }
+
+    match execute_failover(env, vm, dead_host).await {
+        Ok(result) => {
+            let _ = jobs::mark_completed(env.pool(), job.id, Some(result)).await;
+        }
+        Err(error) => {
+            warn!(
+                "HA monitor: failover of VM {} from host {} failed: {}",
+                vm.name, dead_host.name, error
+            );
+            let _ = jobs::mark_failed(env.pool(), job.id, &error.to_string()).await;
+        }
+    }
+}
+
+async fn execute_failover(
+    env: &App,
+    vm: &Vm,
+    dead_host: &Host,
+) -> Result<serde_json::Value, Error> {
+    if !host_gpus::list_by_vm(env.pool(), vm.id).await?.is_empty() {
+        return Err(Error::UnprocessableEntity(
+            "HA failover is not supported for VMs with attached GPUs".into(),
+        ));
+    }
+
+    let required_pool_ids = shared_disk_pool_ids(env, vm).await?;
+    let target = pick_failover_host(env, vm, dead_host.id, &required_pool_ids).await?;
+
+    // Best-effort: if the dead host is partially alive, remove the old copy
+    // before starting elsewhere.
+    let old_client = NodeClient::new(&dead_host.address, dead_host.port as u16);
+    let _ = old_client.force_stop_vm(vm.id).await;
+    let _ = old_client.delete_vm(vm.id).await;
+
+    // Tag the VM so the stale copy is cleaned up if the source host recovers.
+    let mut config = vm.config.clone();
+    vms::set_failed_over_from(&mut config, Some(dead_host.id));
+    vms::update_config(env.pool(), vm.id, &config).await?;
+
+    vms::update_host_id(env.pool(), vm.id, target.id).await?;
+    // Created makes the start path re-create the VM on the new host.
+    vms::update_status(env.pool(), vm.id, VmStatus::Created).await?;
+
+    let start_job_id = start_vm_internal(env, vm.id).await?;
+
+    info!(
+        "HA monitor: VM {} ({}) failed over from host {} to host {} (start job {})",
+        vm.name, vm.id, dead_host.name, target.name, start_job_id
+    );
+
+    Ok(serde_json::json!({
+        "source_host_id": dead_host.id,
+        "target_host_id": target.id,
+        "start_job_id": start_job_id,
+    }))
+}
+
+/// Pool IDs backing the VM's disks (including persistent OverlayBD upper
+/// layers). Errors if any of them is not on shared storage — such disks
+/// cannot be reattached on another host.
+async fn shared_disk_pool_ids(env: &App, vm: &Vm) -> Result<Vec<Uuid>, Error> {
+    let db_disks = vm_disks::list_by_vm(env.pool(), vm.id).await?;
+    let so_ids: Vec<Uuid> = db_disks
+        .iter()
+        .filter_map(|d| d.storage_object_id)
+        .chain(db_disks.iter().filter_map(|d| d.upper_storage_object_id))
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    if so_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let objects = storage_objects::get_batch(env.pool(), &so_ids).await?;
+    let pool_ids: Vec<Uuid> = objects
+        .iter()
+        .map(|o| o.storage_pool_id)
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    let pools = storage_pools::get_batch(env.pool(), &pool_ids).await?;
+    for pool in &pools {
+        if !pool.pool_type.is_shared() {
+            return Err(Error::UnprocessableEntity(format!(
+                "disk on pool '{}' ({:?}) is not on shared storage; cannot fail over",
+                pool.name, pool.pool_type
+            )));
+        }
+    }
+
+    Ok(pool_ids)
+}
+
+/// Pick a destination host for the VM, excluding the dead host and any
+/// candidate that does not have all required storage pools attached.
+async fn pick_failover_host(
+    env: &App,
+    vm: &Vm,
+    dead_host_id: Uuid,
+    required_pool_ids: &[Uuid],
+) -> Result<Host, Error> {
+    let base_request = evacuation_scheduling_request(env, vm, dead_host_id).await?;
+    let mut excluded_host_ids = base_request.excluded_host_ids.clone();
+
+    loop {
+        let mut tx = env.pool().begin().await?;
+        let candidate = hosts::pick_host_tx(
+            &mut tx,
+            &hosts::SchedulingRequest {
+                excluded_host_ids: excluded_host_ids.clone(),
+                ..base_request.clone()
+            },
+            env.scheduling(),
+        )
+        .await?;
+        drop(tx);
+
+        let Some(candidate) = candidate else {
+            return Err(Error::UnprocessableEntity(format!(
+                "no eligible destination host found for VM '{}'",
+                vm.name
+            )));
+        };
+
+        let mut has_all_pools = true;
+        for pool_id in required_pool_ids {
+            if !storage_pools::host_has_pool(env.pool(), candidate.id, *pool_id).await? {
+                has_all_pools = false;
+                break;
+            }
+        }
+        if has_all_pools {
+            return Ok(candidate);
+        }
+        excluded_host_ids.push(candidate.id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::{Connection, Executor, PgConnection, PgPool};
+    use uuid::Uuid;
+
+    use super::collect_failover_candidates;
+    use crate::{
+        App,
+        configuration::{default_control_plane_architecture, get_configuration},
+        model::{
+            hosts::{self, HostStatus, NewHost},
+            vms::{self, BootMode, Hypervisor, ResolvedNewVm, VmStatus},
+        },
+    };
+
+    #[test]
+    fn ha_enabled_defaults_to_false() {
+        assert!(!vms::ha_enabled(&serde_json::json!({})));
+        assert!(!vms::ha_enabled(&serde_json::Value::Null));
+        assert!(vms::ha_enabled(&serde_json::json!({"ha_enabled": true})));
+    }
+
+    #[test]
+    fn set_ha_enabled_config_round_trips() {
+        let mut config = serde_json::Value::Null;
+        vms::set_ha_enabled_config(&mut config, true);
+        assert!(vms::ha_enabled(&config));
+        vms::set_ha_enabled_config(&mut config, false);
+        assert!(!vms::ha_enabled(&config));
+    }
+
+    #[test]
+    fn failed_over_from_round_trips() {
+        let host_id = Uuid::new_v4();
+        let mut config = serde_json::json!({"ha_enabled": true});
+
+        vms::set_failed_over_from(&mut config, Some(host_id));
+        assert_eq!(vms::failed_over_from(&config), Some(host_id));
+        // The HA flag must survive the marker updates.
+        assert!(vms::ha_enabled(&config));
+
+        vms::set_failed_over_from(&mut config, None);
+        assert_eq!(vms::failed_over_from(&config), None);
+        assert!(vms::ha_enabled(&config));
+    }
+
+    struct TestDatabase {
+        name: String,
+        pool: PgPool,
+    }
+
+    impl TestDatabase {
+        async fn new() -> Self {
+            let mut configuration = get_configuration().expect("Failed to read configuration");
+            configuration.database.name = Uuid::new_v4().to_string();
+
+            let mut connection =
+                PgConnection::connect(&configuration.database.connection_string_without_db())
+                    .await
+                    .expect("Failed to connect to Postgres");
+            connection
+                .execute(format!(r#"CREATE DATABASE "{}";"#, configuration.database.name).as_str())
+                .await
+                .expect("Failed to create test database");
+
+            let pool = PgPool::connect(&configuration.database.connection_string())
+                .await
+                .expect("Failed to connect to test database");
+            sqlx::migrate!("../migrations")
+                .run(&pool)
+                .await
+                .expect("Failed to run migrations");
+
+            Self {
+                name: configuration.database.name,
+                pool,
+            }
+        }
+
+        fn app(&self) -> App {
+            let mut configuration = get_configuration().expect("Failed to read configuration");
+            configuration.database.name = self.name.clone();
+            App::new(
+                self.pool.clone(),
+                configuration.database,
+                configuration.vm_defaults,
+                configuration.scheduling,
+                configuration.sandbox,
+                default_control_plane_architecture(),
+            )
+        }
+
+        async fn insert_down_host(&self) -> Uuid {
+            let host_id = hosts::add(
+                &self.pool,
+                &NewHost {
+                    name: "ha-test-host".to_string(),
+                    address: "127.0.0.1".to_string(),
+                    port: 50051,
+                    host_user: "root".to_string(),
+                    password: String::new(),
+                    reservation_class: None,
+                    placement_labels: std::collections::BTreeMap::new(),
+                },
+            )
+            .await
+            .expect("Failed to insert host");
+
+            hosts::update_status(&self.pool, host_id, HostStatus::Down)
+                .await
+                .expect("Failed to mark host DOWN");
+            host_id
+        }
+
+        async fn insert_vm(&self, name: &str, host_id: Uuid, status: VmStatus, ha: bool) -> Uuid {
+            let resolved = ResolvedNewVm {
+                name: name.to_string(),
+                tags: vec![],
+                hypervisor: Hypervisor::CloudHv,
+                architecture: None,
+                boot_vcpus: 1,
+                max_vcpus: 1,
+                cpu_topology: None,
+                kvm_hyperv: None,
+                memory_size: 256 * 1024 * 1024,
+                memory_hotplug_size: None,
+                memory_mergeable: None,
+                memory_shared: None,
+                memory_hugepages: None,
+                memory_hugepage_size: None,
+                memory_prefault: None,
+                memory_thp: None,
+                boot_source_id: None,
+                root_disk_object_id: None,
+                boot_mode: Some(BootMode::Kernel),
+                description: None,
+                image_ref: None,
+                cloud_init_user_data: None,
+                cloud_init_meta_data: None,
+                cloud_init_network_config: None,
+                network_id: None,
+                networks: None,
+                security_group_ids: None,
+                accelerator_config: None,
+                numa_config: None,
+                persistent_upper_pool_id: None,
+                placement_policy: None,
+                config: serde_json::json!({ "ha_enabled": ha }),
+            };
+            let vm_id = vms::create(&self.pool, &resolved)
+                .await
+                .expect("Failed to insert VM");
+            vms::update_host_id(&self.pool, vm_id, host_id)
+                .await
+                .expect("Failed to assign VM host");
+            vms::update_status(&self.pool, vm_id, status)
+                .await
+                .expect("Failed to set VM status");
+            vm_id
+        }
+    }
+
+    impl Drop for TestDatabase {
+        fn drop(&mut self) {
+            let db_name = self.name.clone();
+            let (tx, rx) = std::sync::mpsc::channel();
+
+            std::thread::spawn(move || {
+                let rt = tokio::runtime::Runtime::new().expect("Failed to create runtime");
+                rt.block_on(async move {
+                    let configuration = get_configuration().expect("Failed to read configuration");
+                    let mut connection =
+                        PgConnection::connect_with(&configuration.database.without_db())
+                            .await
+                            .expect("Failed to connect to Postgres");
+                    connection
+                        .execute(&*format!(r#"DROP DATABASE "{}" WITH (FORCE)"#, db_name))
+                        .await
+                        .expect("Failed to drop test database");
+                    let _ = tx.send(());
+                });
+            });
+
+            let _ = rx.recv();
+        }
+    }
+
+    #[tokio::test]
+    async fn only_running_ha_vms_are_failover_candidates() {
+        let db = TestDatabase::new().await;
+        let host_id = db.insert_down_host().await;
+
+        let ha_running = db
+            .insert_vm("ha-running", host_id, VmStatus::Running, true)
+            .await;
+        let ha_unknown = db
+            .insert_vm("ha-unknown", host_id, VmStatus::Unknown, true)
+            .await;
+        let _non_ha_running = db
+            .insert_vm("plain-running", host_id, VmStatus::Running, false)
+            .await;
+        let _ha_stopped = db
+            .insert_vm("ha-stopped", host_id, VmStatus::Shutdown, true)
+            .await;
+
+        let candidates = collect_failover_candidates(&db.app(), host_id)
+            .await
+            .expect("Failed to collect candidates");
+
+        let mut ids: Vec<Uuid> = candidates.iter().map(|vm| vm.id).collect();
+        ids.sort();
+        let mut expected = vec![ha_running, ha_unknown];
+        expected.sort();
+        assert_eq!(ids, expected);
+    }
+
+    #[tokio::test]
+    async fn failed_over_vms_are_listed_by_source_host() {
+        let db = TestDatabase::new().await;
+        let host_id = db.insert_down_host().await;
+        let vm_id = db
+            .insert_vm("ha-failed-over", host_id, VmStatus::Running, true)
+            .await;
+
+        let vm = vms::get(&db.pool, vm_id).await.expect("Failed to get VM");
+        let mut config = vm.config.clone();
+        vms::set_failed_over_from(&mut config, Some(host_id));
+        vms::update_config(&db.pool, vm_id, &config)
+            .await
+            .expect("Failed to update VM config");
+
+        let listed = vms::list_failed_over_from(&db.pool, host_id)
+            .await
+            .expect("Failed to list failed-over VMs");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, vm_id);
+
+        vms::set_failed_over_from(&mut config, None);
+        vms::update_config(&db.pool, vm_id, &config)
+            .await
+            .expect("Failed to clear marker");
+
+        let listed = vms::list_failed_over_from(&db.pool, host_id)
+            .await
+            .expect("Failed to list failed-over VMs");
+        assert!(listed.is_empty());
+    }
+}

--- a/qarax/src/ha_monitor.rs
+++ b/qarax/src/ha_monitor.rs
@@ -85,7 +85,11 @@ async fn run_cycle(env: &App, settings: &HaSettings, state: &mut MonitorState) {
 
     for host in down_hosts {
         let client = NodeClient::new(&host.address, host.port as u16);
-        if client.get_node_info().await.is_ok() {
+        let is_reachable = tokio::time::timeout(Duration::from_secs(5), client.get_node_info())
+            .await
+            .map(|res| res.is_ok())
+            .unwrap_or(false);
+        if is_reachable {
             // The host is reachable despite being marked Down (e.g. it
             // recovered before an operator re-enabled it). Never fail over
             // from a live host; instead remove stale copies of VMs that were
@@ -264,10 +268,12 @@ async fn execute_failover(
     let target = pick_failover_host(env, vm, dead_host.id, &required_pool_ids).await?;
 
     // Best-effort: if the dead host is partially alive, remove the old copy
-    // before starting elsewhere.
+    // before starting elsewhere. Use a short timeout since the host is
+    // already known to be unreachable.
     let old_client = NodeClient::new(&dead_host.address, dead_host.port as u16);
-    let _ = old_client.force_stop_vm(vm.id).await;
-    let _ = old_client.delete_vm(vm.id).await;
+    let cleanup_timeout = Duration::from_secs(2);
+    let _ = tokio::time::timeout(cleanup_timeout, old_client.force_stop_vm(vm.id)).await;
+    let _ = tokio::time::timeout(cleanup_timeout, old_client.delete_vm(vm.id)).await;
 
     // Tag the VM so the stale copy is cleaned up if the source host recovers.
     let mut config = vm.config.clone();
@@ -278,7 +284,18 @@ async fn execute_failover(
     // Created makes the start path re-create the VM on the new host.
     vms::update_status(env.pool(), vm.id, VmStatus::Created).await?;
 
-    let start_job_id = start_vm_internal(env, vm.id).await?;
+    let start_job_id = match start_vm_internal(env, vm.id).await {
+        Ok(job_id) => job_id,
+        Err(e) => {
+            // Revert so the HA monitor picks this VM back up as a candidate
+            // and retries on a subsequent tick, instead of leaving it
+            // stranded in `Created` on the target host.
+            let _ = vms::update_host_id(env.pool(), vm.id, dead_host.id).await;
+            let _ = vms::update_status(env.pool(), vm.id, vm.status).await;
+            let _ = vms::update_config(env.pool(), vm.id, &vm.config).await;
+            return Err(e);
+        }
+    };
 
     info!(
         "HA monitor: VM {} ({}) failed over from host {} to host {} (start job {})",

--- a/qarax/src/handlers/host/handler.rs
+++ b/qarax/src/handlers/host/handler.rs
@@ -90,7 +90,10 @@ fn persisted_vm_placement_policy(vm: &Vm) -> Option<crate::model::vms::Placement
     crate::model::vms::placement_policy_from_config(&vm.config)
 }
 
-async fn evacuation_scheduling_request(
+/// Build a scheduling request to move an existing VM off `source_host_id`,
+/// preserving its resource needs, networks, and placement policy. Used by
+/// host evacuation and HA failover.
+pub(crate) async fn evacuation_scheduling_request(
     env: &App,
     vm: &Vm,
     source_host_id: Uuid,

--- a/qarax/src/handlers/mod.rs
+++ b/qarax/src/handlers/mod.rs
@@ -29,7 +29,7 @@ mod audit_log;
 mod backup;
 mod boot_source;
 mod events;
-mod host;
+pub(crate) mod host;
 mod instance_type;
 mod job;
 mod lifecycle_hook;

--- a/qarax/src/lib.rs
+++ b/qarax/src/lib.rs
@@ -2,6 +2,7 @@ pub mod configuration;
 pub mod database;
 pub mod errors;
 pub mod grpc_client;
+pub mod ha_monitor;
 pub mod handlers;
 pub mod hook_executor;
 pub mod host_deployer;

--- a/qarax/src/main.rs
+++ b/qarax/src/main.rs
@@ -75,6 +75,7 @@ async fn main() -> std::io::Result<()> {
         vm_defaults,
         scheduling,
         sandbox,
+        configuration.ha.clone(),
         default_control_plane_architecture(),
     )
     .await

--- a/qarax/src/model/hosts.rs
+++ b/qarax/src/model/hosts.rs
@@ -571,6 +571,17 @@ pub async fn list_up(pool: &PgPool) -> Result<Vec<Host>, sqlx::Error> {
     Ok(rows.into_iter().map(|r| host_from_row(&r)).collect())
 }
 
+/// Return all DOWN hosts (candidates for HA failover).
+pub async fn list_down(pool: &PgPool) -> Result<Vec<Host>, sqlx::Error> {
+    let rows = sqlx::query(&format!(
+        "SELECT {HOST_COLUMNS} FROM hosts WHERE status = 'DOWN'"
+    ))
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows.into_iter().map(|r| host_from_row(&r)).collect())
+}
+
 /// Return hosts that should continue receiving health/resource probes.
 pub async fn list_probeable(pool: &PgPool) -> Result<Vec<Host>, sqlx::Error> {
     let rows = sqlx::query(&format!(

--- a/qarax/src/model/jobs.rs
+++ b/qarax/src/model/jobs.rs
@@ -34,6 +34,7 @@ pub enum JobType {
     SandboxClaim,
     VmStart,
     VmMigrate,
+    VmFailover,
     HostEvacuate,
     DiskCreate,
     VmCommit,

--- a/qarax/src/model/vms.rs
+++ b/qarax/src/model/vms.rs
@@ -44,6 +44,8 @@ pub struct PlacementPolicy {
 
 pub const GUEST_AGENT_CONFIG_KEY: &str = "guest_agent";
 const LEGACY_SANDBOX_EXEC_CONFIG_KEY: &str = "sandbox_exec";
+pub const HA_ENABLED_CONFIG_KEY: &str = "ha_enabled";
+pub const FAILED_OVER_FROM_CONFIG_KEY: &str = "failed_over_from";
 
 pub fn guest_agent_enabled(config: &serde_json::Value) -> bool {
     config
@@ -68,6 +70,55 @@ pub fn set_guest_agent_config(config: &mut serde_json::Value, enabled: bool) {
             serde_json::Value::Bool(enabled),
         );
         map.remove(LEGACY_SANDBOX_EXEC_CONFIG_KEY);
+    }
+}
+
+pub fn ha_enabled(config: &serde_json::Value) -> bool {
+    config
+        .get(HA_ENABLED_CONFIG_KEY)
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false)
+}
+
+pub fn set_ha_enabled_config(config: &mut serde_json::Value, enabled: bool) {
+    if !config.is_object() {
+        *config = default_vm_config();
+    }
+
+    if let Some(map) = config.as_object_mut() {
+        map.insert(
+            HA_ENABLED_CONFIG_KEY.to_string(),
+            serde_json::Value::Bool(enabled),
+        );
+    }
+}
+
+/// Host the VM was failed over from, if an HA failover is pending cleanup
+/// (the stale copy on the source host has not been confirmed gone yet).
+pub fn failed_over_from(config: &serde_json::Value) -> Option<Uuid> {
+    config
+        .get(FAILED_OVER_FROM_CONFIG_KEY)
+        .and_then(|value| value.as_str())
+        .and_then(|value| Uuid::parse_str(value).ok())
+}
+
+pub fn set_failed_over_from(config: &mut serde_json::Value, source_host_id: Option<Uuid>) {
+    if !config.is_object() {
+        *config = default_vm_config();
+    }
+
+    if let Some(map) = config.as_object_mut() {
+        match source_host_id {
+            Some(host_id) => {
+                map.insert(
+                    FAILED_OVER_FROM_CONFIG_KEY.to_string(),
+                    serde_json::Value::String(host_id.to_string()),
+                );
+            }
+            None => {
+                map.remove(FAILED_OVER_FROM_CONFIG_KEY);
+            }
+        }
     }
 }
 
@@ -159,6 +210,7 @@ pub struct Vm {
     pub description: Option<String>,
     pub placement_policy: Option<PlacementPolicy>,
     pub guest_agent: bool,
+    pub ha_enabled: bool,
 
     // CPU configuration
     pub boot_vcpus: i32,
@@ -239,6 +291,7 @@ impl From<VmRow> for Vm {
             description: row.description,
             placement_policy: placement_policy_from_config(&row.config.0),
             guest_agent: guest_agent_enabled(&row.config.0),
+            ha_enabled: ha_enabled(&row.config.0),
 
             boot_vcpus: row.boot_vcpus,
             max_vcpus: row.max_vcpus,
@@ -435,6 +488,11 @@ pub struct NewVm {
     /// Enable the guest agent used by `vm exec`.
     pub guest_agent: Option<bool>,
 
+    /// Enable high availability for this VM. When its host fails, the VM is
+    /// automatically restarted on another eligible host. Requires all disks
+    /// to live on shared storage pools.
+    pub ha_enabled: Option<bool>,
+
     #[serde(default = "default_vm_config")]
     pub config: serde_json::Value,
 }
@@ -545,6 +603,7 @@ pub async fn resolve_create_request(pool: &PgPool, request: NewVm) -> Result<Res
         persistent_upper_pool_id,
         placement_policy,
         guest_agent,
+        ha_enabled,
         config,
     } = request;
 
@@ -617,6 +676,9 @@ pub async fn resolve_create_request(pool: &PgPool, request: NewVm) -> Result<Res
     let mut config = config;
     if let Some(enabled) = guest_agent {
         set_guest_agent_config(&mut config, enabled);
+    }
+    if let Some(enabled) = ha_enabled {
+        set_ha_enabled_config(&mut config, enabled);
     }
 
     Ok(ResolvedNewVm {
@@ -1093,6 +1155,66 @@ pub async fn clear_image_ref(pool: &PgPool, vm_id: Uuid) -> Result<(), sqlx::Err
         .execute(pool)
         .await?;
     Ok(())
+}
+
+pub async fn update_config(
+    pool: &PgPool,
+    vm_id: Uuid,
+    config: &serde_json::Value,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE vms SET config = $1 WHERE id = $2")
+        .bind(Json(config))
+        .bind(vm_id)
+        .execute(pool)
+        .await?;
+
+    Ok(())
+}
+
+/// VMs that were failed over from the given host and still await stale-copy
+/// cleanup on it (their config carries `failed_over_from = source_host_id`).
+pub async fn list_failed_over_from(
+    pool: &PgPool,
+    source_host_id: Uuid,
+) -> Result<Vec<Vm>, sqlx::Error> {
+    let vms: Vec<VmRow> = sqlx::query_as!(
+        VmRow,
+        r#"
+SELECT id,
+        name,
+        tags as "tags!",
+        status as "status: _",
+        host_id as "host_id?",
+        hypervisor as "hypervisor: _",
+        boot_source_id as "boot_source_id?",
+        boot_mode as "boot_mode: _",
+        description as "description?",
+        boot_vcpus,
+        max_vcpus,
+        cpu_topology as "cpu_topology: _",
+        kvm_hyperv as "kvm_hyperv!",
+        memory_size,
+        memory_hotplug_size as "memory_hotplug_size?",
+        memory_mergeable as "memory_mergeable!",
+        memory_shared as "memory_shared!",
+        memory_hugepages as "memory_hugepages!",
+        memory_hugepage_size as "memory_hugepage_size?",
+        memory_prefault as "memory_prefault!",
+        memory_thp as "memory_thp!",
+        image_ref as "image_ref?",
+        cloud_init_user_data as "cloud_init_user_data?",
+        cloud_init_meta_data as "cloud_init_meta_data?",
+        cloud_init_network_config as "cloud_init_network_config?",
+        config as "config: _"
+FROM vms
+WHERE config->>'failed_over_from' = $1
+        "#,
+        source_host_id.to_string()
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(vms.into_iter().map(Into::into).collect())
 }
 
 pub async fn update_host_id(pool: &PgPool, vm_id: Uuid, host_id: Uuid) -> Result<(), sqlx::Error> {

--- a/qarax/src/sandbox_runtime.rs
+++ b/qarax/src/sandbox_runtime.rs
@@ -60,6 +60,7 @@ pub(crate) async fn resolve_sandbox_vm(
         persistent_upper_pool_id: None,
         placement_policy: None,
         guest_agent: Some(true),
+        ha_enabled: None,
         config: serde_json::json!({}),
     };
 

--- a/qarax/src/startup.rs
+++ b/qarax/src/startup.rs
@@ -5,10 +5,13 @@ use sqlx::PgPool;
 
 use crate::{
     App,
-    configuration::{DatabaseSettings, SandboxSettings, SchedulingSettings, VmDefaultsSettings},
+    configuration::{
+        DatabaseSettings, HaSettings, SandboxSettings, SchedulingSettings, VmDefaultsSettings,
+    },
     handlers::app,
 };
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     listener: TcpListener,
     db_pool: PgPool,
@@ -16,6 +19,7 @@ pub async fn run(
     vm_defaults: VmDefaultsSettings,
     scheduling: SchedulingSettings,
     sandbox: SandboxSettings,
+    ha: HaSettings,
     control_plane_architecture: String,
 ) -> Result<impl IntoFuture<Output = std::io::Result<()>> + Send, Box<dyn std::error::Error + Send>>
 {
@@ -35,6 +39,9 @@ pub async fn run(
 
     // Spawn background task to poll host resource metrics
     tokio::spawn(crate::resource_monitor::start_resource_monitor(a.clone()));
+
+    // Spawn background task to fail over HA-enabled VMs from dead hosts
+    tokio::spawn(crate::ha_monitor::start_ha_monitor(a.clone(), ha));
 
     // Spawn background task to deliver lifecycle hook webhooks
     tokio::spawn(crate::hook_executor::start_hook_executor(a.clone()));

--- a/qarax/tests/audit_logs.rs
+++ b/qarax/tests/audit_logs.rs
@@ -68,6 +68,7 @@ async fn spawn_app() -> TestApp {
         configuration.vm_defaults.clone(),
         configuration.scheduling.clone(),
         configuration.sandbox.clone(),
+        configuration.ha.clone(),
         default_control_plane_architecture(),
     )
     .await

--- a/qarax/tests/hosts.rs
+++ b/qarax/tests/hosts.rs
@@ -69,6 +69,7 @@ async fn spawn_app() -> TestApp {
         configuration.vm_defaults.clone(),
         configuration.scheduling.clone(),
         configuration.sandbox.clone(),
+        configuration.ha.clone(),
         default_control_plane_architecture(),
     )
     .await;

--- a/qarax/tests/sandbox_pools.rs
+++ b/qarax/tests/sandbox_pools.rs
@@ -66,6 +66,7 @@ async fn spawn_app() -> TestApp {
         configuration.vm_defaults.clone(),
         configuration.scheduling.clone(),
         configuration.sandbox.clone(),
+        configuration.ha.clone(),
         default_control_plane_architecture(),
     )
     .await

--- a/qarax/tests/snapshots.rs
+++ b/qarax/tests/snapshots.rs
@@ -67,6 +67,7 @@ async fn spawn_app() -> TestApp {
         configuration.vm_defaults.clone(),
         configuration.scheduling.clone(),
         configuration.sandbox.clone(),
+        configuration.ha.clone(),
         default_control_plane_architecture(),
     )
     .await

--- a/qarax/tests/storage_cleanup.rs
+++ b/qarax/tests/storage_cleanup.rs
@@ -74,6 +74,7 @@ async fn spawn_app() -> TestApp {
         configuration.vm_defaults.clone(),
         configuration.scheduling.clone(),
         configuration.sandbox.clone(),
+        configuration.ha.clone(),
         default_control_plane_architecture(),
     )
     .await

--- a/qarax/tests/storage_pools.rs
+++ b/qarax/tests/storage_pools.rs
@@ -73,6 +73,7 @@ async fn spawn_app() -> TestApp {
         configuration.vm_defaults.clone(),
         configuration.scheduling.clone(),
         configuration.sandbox.clone(),
+        configuration.ha.clone(),
         default_control_plane_architecture(),
     )
     .await

--- a/qarax/tests/vm_templates.rs
+++ b/qarax/tests/vm_templates.rs
@@ -68,6 +68,7 @@ async fn spawn_app() -> TestApp {
         configuration.vm_defaults.clone(),
         configuration.scheduling.clone(),
         configuration.sandbox.clone(),
+        configuration.ha.clone(),
         default_control_plane_architecture(),
     )
     .await

--- a/qarax/tests/vms.rs
+++ b/qarax/tests/vms.rs
@@ -68,6 +68,7 @@ async fn spawn_app() -> TestApp {
         configuration.vm_defaults.clone(),
         configuration.scheduling.clone(),
         configuration.sandbox.clone(),
+        configuration.ha.clone(),
         default_control_plane_architecture(),
     )
     .await


### PR DESCRIPTION
## Summary
- Background `ha_monitor` task detects hosts unreachable for `ha.failover_grace_seconds` and cold-restarts their HA-enabled VMs on another eligible host via the regular scheduler.
- Split-brain guard: only VMs whose disks all live on shared storage pools are eligible. Failed-over VMs are tagged with `failed_over_from`; if the source host recovers while still marked Down, the stale copies are force-stopped and deleted before re-accepting traffic.
- New `vm_failover` job type and migration, `ha_enabled` / `failed_over_from` VM config keys, `ha` configuration section, and CLI `--ha-enabled` flag on `vm create`.
- Also bumps russh to 0.60.3 to fix RUSTSEC-2026-0154 and RUSTSEC-2026-0153.

## Test plan
- [ ] CI: fmt, lint, test, sqlx-check, audit, openapi-check, python-sdk-lint
- [ ] E2E: `e2e/test_ha_failover.py` failover scenario