### PR TITLE
Support GPU reallocation during HA VM failover

### DIFF
--- a/qarax/src/ha_monitor.rs
+++ b/qarax/src/ha_monitor.rs
@@ -263,10 +263,6 @@ async fn execute_failover(
     let target =
         pick_failover_host(env, vm, dead_host.id, &required_pool_ids, &gpu_request).await?;
 
-    if let Some(gpu_request) = &gpu_request {
-        reallocate_vm_gpus(env, vm.id, target.id, gpu_request).await?;
-    }
-
     // Best-effort: if the dead host is partially alive, remove the old copy
     // before starting elsewhere. Use a short timeout since the host is
     // already known to be unreachable.
@@ -284,15 +280,23 @@ async fn execute_failover(
     // Created makes the start path re-create the VM on the new host.
     vms::update_status(env.pool(), vm.id, VmStatus::Created).await?;
 
+    if let Some(gpu_request) = &gpu_request
+        && let Err(e) = reallocate_vm_gpus(env, vm.id, target.id, gpu_request).await
+    {
+        revert_failover_state(env, vm, dead_host.id).await;
+        return Err(e);
+    }
+
     let start_job_id = match start_vm_internal(env, vm.id).await {
         Ok(job_id) => job_id,
         Err(e) => {
             // Revert so the HA monitor picks this VM back up as a candidate
             // and retries on a subsequent tick, instead of leaving it
             // stranded in `Created` on the target host.
-            let _ = vms::update_host_id(env.pool(), vm.id, dead_host.id).await;
-            let _ = vms::update_status(env.pool(), vm.id, vm.status).await;
-            let _ = vms::update_config(env.pool(), vm.id, &vm.config).await;
+            revert_failover_state(env, vm, dead_host.id).await;
+            if let Some(gpu_request) = &gpu_request {
+                let _ = reallocate_vm_gpus(env, vm.id, dead_host.id, gpu_request).await;
+            }
             return Err(e);
         }
     };
@@ -309,6 +313,14 @@ async fn execute_failover(
     }))
 }
 
+/// Best-effort revert of the VM's host/status/config changes made during a
+/// failed failover attempt, so the HA monitor retries it on a later tick.
+async fn revert_failover_state(env: &App, vm: &Vm, dead_host_id: Uuid) {
+    let _ = vms::update_host_id(env.pool(), vm.id, dead_host_id).await;
+    let _ = vms::update_status(env.pool(), vm.id, vm.status).await;
+    let _ = vms::update_config(env.pool(), vm.id, &vm.config).await;
+}
+
 /// GPU requirements derived from the GPUs currently allocated to the VM on
 /// the dead host. `None` means the VM has no GPUs attached.
 async fn gpu_request_for_vm(env: &App, vm: &Vm) -> Result<Option<hosts::GpuRequest>, Error> {
@@ -319,8 +331,8 @@ async fn gpu_request_for_vm(env: &App, vm: &Vm) -> Result<Option<hosts::GpuReque
 
     Ok(Some(hosts::GpuRequest {
         count: allocated.len() as i32,
-        vendor: allocated[0].vendor.clone(),
-        model: allocated[0].model.clone(),
+        vendor: allocated.iter().find_map(|g| g.vendor.clone()),
+        model: allocated.iter().find_map(|g| g.model.clone()),
         min_vram_bytes: allocated.iter().filter_map(|g| g.vram_bytes).min(),
     }))
 }

--- a/qarax/src/ha_monitor.rs
+++ b/qarax/src/ha_monitor.rs
@@ -258,14 +258,14 @@ async fn execute_failover(
     vm: &Vm,
     dead_host: &Host,
 ) -> Result<serde_json::Value, Error> {
-    if !host_gpus::list_by_vm(env.pool(), vm.id).await?.is_empty() {
-        return Err(Error::UnprocessableEntity(
-            "HA failover is not supported for VMs with attached GPUs".into(),
-        ));
-    }
-
     let required_pool_ids = shared_disk_pool_ids(env, vm).await?;
-    let target = pick_failover_host(env, vm, dead_host.id, &required_pool_ids).await?;
+    let gpu_request = gpu_request_for_vm(env, vm).await?;
+    let target =
+        pick_failover_host(env, vm, dead_host.id, &required_pool_ids, &gpu_request).await?;
+
+    if let Some(gpu_request) = &gpu_request {
+        reallocate_vm_gpus(env, vm.id, target.id, gpu_request).await?;
+    }
 
     // Best-effort: if the dead host is partially alive, remove the old copy
     // before starting elsewhere. Use a short timeout since the host is
@@ -307,6 +307,56 @@ async fn execute_failover(
         "target_host_id": target.id,
         "start_job_id": start_job_id,
     }))
+}
+
+/// GPU requirements derived from the GPUs currently allocated to the VM on
+/// the dead host. `None` means the VM has no GPUs attached.
+async fn gpu_request_for_vm(env: &App, vm: &Vm) -> Result<Option<hosts::GpuRequest>, Error> {
+    let allocated = host_gpus::list_by_vm(env.pool(), vm.id).await?;
+    if allocated.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(hosts::GpuRequest {
+        count: allocated.len() as i32,
+        vendor: allocated[0].vendor.clone(),
+        model: allocated[0].model.clone(),
+        min_vram_bytes: allocated.iter().filter_map(|g| g.vram_bytes).min(),
+    }))
+}
+
+/// Move the VM's GPU allocation from the dead host to `target_host_id`,
+/// atomically within a transaction so a partial allocation never leaves the
+/// VM without its required GPUs.
+async fn reallocate_vm_gpus(
+    env: &App,
+    vm_id: Uuid,
+    target_host_id: Uuid,
+    gpu_request: &hosts::GpuRequest,
+) -> Result<(), Error> {
+    let mut tx = env.pool().begin().await?;
+    host_gpus::deallocate_by_vm_tx(&mut tx, vm_id).await?;
+    let allocated = host_gpus::allocate_gpus(
+        &mut tx,
+        target_host_id,
+        vm_id,
+        gpu_request.count,
+        gpu_request.vendor.as_deref(),
+        gpu_request.model.as_deref(),
+        gpu_request.min_vram_bytes,
+    )
+    .await?;
+
+    if (allocated.len() as i32) < gpu_request.count {
+        return Err(Error::UnprocessableEntity(format!(
+            "requested {} GPUs for failover but only {} available on target host",
+            gpu_request.count,
+            allocated.len()
+        )));
+    }
+
+    tx.commit().await?;
+    Ok(())
 }
 
 /// Pool IDs backing the VM's disks (including persistent OverlayBD upper
@@ -352,8 +402,10 @@ async fn pick_failover_host(
     vm: &Vm,
     dead_host_id: Uuid,
     required_pool_ids: &[Uuid],
+    gpu_request: &Option<hosts::GpuRequest>,
 ) -> Result<Host, Error> {
-    let base_request = evacuation_scheduling_request(env, vm, dead_host_id).await?;
+    let base_request =
+        evacuation_scheduling_request(env, vm, dead_host_id, gpu_request.clone()).await?;
     let mut excluded_host_ids = base_request.excluded_host_ids.clone();
 
     loop {
@@ -395,12 +447,13 @@ mod tests {
     use sqlx::{Connection, Executor, PgConnection, PgPool};
     use uuid::Uuid;
 
-    use super::collect_failover_candidates;
+    use super::{collect_failover_candidates, gpu_request_for_vm, reallocate_vm_gpus};
     use crate::{
         App,
         configuration::{default_control_plane_architecture, get_configuration},
         model::{
-            hosts::{self, HostStatus, NewHost},
+            host_gpus::{self, GpuDiscovery},
+            hosts::{self, GpuRequest, HostStatus, NewHost},
             vms::{self, BootMode, Hypervisor, ResolvedNewVm, VmStatus},
         },
     };
@@ -483,11 +536,16 @@ mod tests {
         }
 
         async fn insert_down_host(&self) -> Uuid {
+            self.insert_down_host_with_address("ha-test-host", "127.0.0.1")
+                .await
+        }
+
+        async fn insert_down_host_with_address(&self, name: &str, address: &str) -> Uuid {
             let host_id = hosts::add(
                 &self.pool,
                 &NewHost {
-                    name: "ha-test-host".to_string(),
-                    address: "127.0.0.1".to_string(),
+                    name: name.to_string(),
+                    address: address.to_string(),
                     port: 50051,
                     host_user: "root".to_string(),
                     password: String::new(),
@@ -636,5 +694,185 @@ mod tests {
             .await
             .expect("Failed to list failed-over VMs");
         assert!(listed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn gpu_request_reflects_current_allocation() {
+        let db = TestDatabase::new().await;
+        let host_id = db.insert_down_host().await;
+        let vm_id = db
+            .insert_vm("gpu-vm", host_id, VmStatus::Running, true)
+            .await;
+
+        host_gpus::sync_gpus(
+            &db.pool,
+            host_id,
+            &[GpuDiscovery {
+                pci_address: "0000:00:01.0".to_string(),
+                model: "A100".to_string(),
+                vendor: "nvidia".to_string(),
+                vram_bytes: 80 * 1024 * 1024 * 1024,
+                iommu_group: 1,
+                numa_node: 0,
+            }],
+        )
+        .await
+        .expect("Failed to sync GPUs");
+
+        let mut tx = db.pool.begin().await.expect("Failed to begin tx");
+        let allocated = host_gpus::allocate_gpus(&mut tx, host_id, vm_id, 1, None, None, None)
+            .await
+            .expect("Failed to allocate GPU");
+        assert_eq!(allocated.len(), 1);
+        tx.commit().await.expect("Failed to commit");
+
+        let vm = vms::get(&db.pool, vm_id).await.expect("Failed to get VM");
+        let gpu_request = gpu_request_for_vm(&db.app(), &vm)
+            .await
+            .expect("Failed to compute GPU request")
+            .expect("Expected a GPU request");
+
+        assert_eq!(gpu_request.count, 1);
+        assert_eq!(gpu_request.vendor, Some("nvidia".to_string()));
+        assert_eq!(gpu_request.model, Some("A100".to_string()));
+        assert_eq!(gpu_request.min_vram_bytes, Some(80 * 1024 * 1024 * 1024));
+    }
+
+    #[tokio::test]
+    async fn gpu_request_is_none_without_allocated_gpus() {
+        let db = TestDatabase::new().await;
+        let host_id = db.insert_down_host().await;
+        let vm_id = db
+            .insert_vm("no-gpu-vm", host_id, VmStatus::Running, true)
+            .await;
+
+        let vm = vms::get(&db.pool, vm_id).await.expect("Failed to get VM");
+        let gpu_request = gpu_request_for_vm(&db.app(), &vm)
+            .await
+            .expect("Failed to compute GPU request");
+        assert!(gpu_request.is_none());
+    }
+
+    #[tokio::test]
+    async fn reallocate_vm_gpus_moves_allocation_to_target_host() {
+        let db = TestDatabase::new().await;
+        let dead_host_id = db
+            .insert_down_host_with_address("ha-test-host-dead", "127.0.0.1")
+            .await;
+        let target_host_id = db
+            .insert_down_host_with_address("ha-test-host-target", "127.0.0.2")
+            .await;
+        let vm_id = db
+            .insert_vm("gpu-vm", dead_host_id, VmStatus::Running, true)
+            .await;
+
+        host_gpus::sync_gpus(
+            &db.pool,
+            dead_host_id,
+            &[GpuDiscovery {
+                pci_address: "0000:00:01.0".to_string(),
+                model: "A100".to_string(),
+                vendor: "nvidia".to_string(),
+                vram_bytes: 80 * 1024 * 1024 * 1024,
+                iommu_group: 1,
+                numa_node: 0,
+            }],
+        )
+        .await
+        .expect("Failed to sync GPUs on dead host");
+
+        host_gpus::sync_gpus(
+            &db.pool,
+            target_host_id,
+            &[GpuDiscovery {
+                pci_address: "0000:00:02.0".to_string(),
+                model: "A100".to_string(),
+                vendor: "nvidia".to_string(),
+                vram_bytes: 80 * 1024 * 1024 * 1024,
+                iommu_group: 1,
+                numa_node: 0,
+            }],
+        )
+        .await
+        .expect("Failed to sync GPUs on target host");
+
+        let mut tx = db.pool.begin().await.expect("Failed to begin tx");
+        host_gpus::allocate_gpus(&mut tx, dead_host_id, vm_id, 1, None, None, None)
+            .await
+            .expect("Failed to allocate GPU on dead host");
+        tx.commit().await.expect("Failed to commit");
+
+        let gpu_request = GpuRequest {
+            count: 1,
+            vendor: Some("nvidia".to_string()),
+            model: Some("A100".to_string()),
+            min_vram_bytes: None,
+        };
+        reallocate_vm_gpus(&db.app(), vm_id, target_host_id, &gpu_request)
+            .await
+            .expect("Failed to reallocate GPUs");
+
+        let allocated = host_gpus::list_by_vm(&db.pool, vm_id)
+            .await
+            .expect("Failed to list GPUs by VM");
+        assert_eq!(allocated.len(), 1);
+        assert_eq!(allocated[0].host_id, target_host_id);
+        assert_eq!(allocated[0].pci_address, "0000:00:02.0");
+
+        let dead_host_gpus = host_gpus::list_by_host(&db.pool, dead_host_id)
+            .await
+            .expect("Failed to list GPUs on dead host");
+        assert!(dead_host_gpus[0].vm_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn reallocate_vm_gpus_fails_when_target_lacks_gpus() {
+        let db = TestDatabase::new().await;
+        let dead_host_id = db
+            .insert_down_host_with_address("ha-test-host-dead", "127.0.0.1")
+            .await;
+        let target_host_id = db
+            .insert_down_host_with_address("ha-test-host-target", "127.0.0.2")
+            .await;
+        let vm_id = db
+            .insert_vm("gpu-vm", dead_host_id, VmStatus::Running, true)
+            .await;
+
+        host_gpus::sync_gpus(
+            &db.pool,
+            dead_host_id,
+            &[GpuDiscovery {
+                pci_address: "0000:00:01.0".to_string(),
+                model: "A100".to_string(),
+                vendor: "nvidia".to_string(),
+                vram_bytes: 80 * 1024 * 1024 * 1024,
+                iommu_group: 1,
+                numa_node: 0,
+            }],
+        )
+        .await
+        .expect("Failed to sync GPUs on dead host");
+
+        let mut tx = db.pool.begin().await.expect("Failed to begin tx");
+        host_gpus::allocate_gpus(&mut tx, dead_host_id, vm_id, 1, None, None, None)
+            .await
+            .expect("Failed to allocate GPU on dead host");
+        tx.commit().await.expect("Failed to commit");
+
+        let gpu_request = GpuRequest {
+            count: 1,
+            vendor: Some("nvidia".to_string()),
+            model: Some("A100".to_string()),
+            min_vram_bytes: None,
+        };
+        let result = reallocate_vm_gpus(&db.app(), vm_id, target_host_id, &gpu_request).await;
+        assert!(result.is_err());
+
+        // The original allocation on the dead host must be untouched since
+        // the transaction rolled back without committing the reallocation.
+        let dead_host_gpus = host_gpus::list_by_host(&db.pool, dead_host_id)
+            .await
+            .expect("Failed to list GPUs on dead host");
+        assert_eq!(dead_host_gpus[0].vm_id, Some(vm_id));
     }
 }

--- a/qarax/src/handlers/host/handler.rs
+++ b/qarax/src/handlers/host/handler.rs
@@ -97,6 +97,7 @@ pub(crate) async fn evacuation_scheduling_request(
     env: &App,
     vm: &Vm,
     source_host_id: Uuid,
+    gpu: Option<hosts::GpuRequest>,
 ) -> Result<hosts::SchedulingRequest> {
     let required_network_ids = network_interfaces::list_by_vm(env.pool(), vm.id)
         .await?
@@ -113,7 +114,7 @@ pub(crate) async fn evacuation_scheduling_request(
         architecture: persisted_vm_architecture(vm),
         storage_pool_id: None,
         required_network_ids,
-        gpu: None,
+        gpu,
         placement_policy: persisted_vm_placement_policy(vm),
         excluded_host_ids: vec![source_host_id],
     })
@@ -124,7 +125,7 @@ async fn pick_evacuation_plan(
     vm: &Vm,
     source_host_id: Uuid,
 ) -> Result<PlannedVmMigration> {
-    let base_request = evacuation_scheduling_request(env, vm, source_host_id).await?;
+    let base_request = evacuation_scheduling_request(env, vm, source_host_id, None).await?;
     let mut excluded_host_ids = base_request.excluded_host_ids.clone();
     let mut last_reason = None;
 

--- a/qarax/src/model/host_gpus.rs
+++ b/qarax/src/model/host_gpus.rs
@@ -196,3 +196,16 @@ pub async fn deallocate_by_vm(pool: &PgPool, vm_id: Uuid) -> Result<u64, sqlx::E
             .await?;
     Ok(result.rows_affected())
 }
+
+/// Release all GPUs allocated to a VM, within an existing transaction.
+pub async fn deallocate_by_vm_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    vm_id: Uuid,
+) -> Result<u64, sqlx::Error> {
+    let result =
+        sqlx::query("UPDATE host_gpus SET vm_id = NULL, updated_at = NOW() WHERE vm_id = $1")
+            .bind(vm_id)
+            .execute(tx.as_mut())
+            .await?;
+    Ok(result.rows_affected())
+}


### PR DESCRIPTION
Previously HA failover refused VMs with attached GPUs. Derive the VM's GPU requirements from its current allocation, factor them into target host selection, and atomically move the GPU allocation to the chosen host as part of the failover.