### PR TITLE
Add basic API token authentication

### DIFF
--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -7,9 +7,18 @@ pub struct Client {
 }
 
 impl Client {
-    pub fn new(base_url: &str) -> Self {
+    pub fn new(base_url: &str, token: Option<&str>) -> Self {
+        let mut builder = reqwest::Client::builder();
+        if let Some(token) = token {
+            let mut headers = reqwest::header::HeaderMap::new();
+            let mut auth_value = reqwest::header::HeaderValue::from_str(&format!("Bearer {token}"))
+                .expect("API token must be a valid header value");
+            auth_value.set_sensitive(true);
+            headers.insert(reqwest::header::AUTHORIZATION, auth_value);
+            builder = builder.default_headers(headers);
+        }
         Self {
-            inner: reqwest::Client::new(),
+            inner: builder.build().expect("failed to build HTTP client"),
             base_url: base_url.trim_end_matches('/').to_string(),
         }
     }
@@ -185,5 +194,51 @@ impl Client {
             .with_context(|| format!("DELETE {path}"))?;
         Self::check_error(resp).await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    /// Accepts a single connection, captures the raw request, and replies
+    /// with an empty 200 response.
+    async fn capture_request(listener: TcpListener) -> String {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0u8; 4096];
+        let n = socket.read(&mut buf).await.unwrap();
+        socket
+            .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n")
+            .await
+            .unwrap();
+        String::from_utf8_lossy(&buf[..n]).to_lowercase()
+    }
+
+    #[tokio::test]
+    async fn sets_authorization_header_when_token_provided() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(capture_request(listener));
+
+        let client = Client::new(&format!("http://{addr}"), Some("my-token"));
+        let _ = client.get_text("/").await;
+
+        let request = server.await.unwrap();
+        assert!(request.contains("authorization: bearer my-token"));
+    }
+
+    #[tokio::test]
+    async fn no_authorization_header_when_token_absent() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(capture_request(listener));
+
+        let client = Client::new(&format!("http://{addr}"), None);
+        let _ = client.get_text("/").await;
+
+        let request = server.await.unwrap();
+        assert!(!request.contains("authorization:"));
     }
 }

--- a/cli/src/commands/configure.rs
+++ b/cli/src/commands/configure.rs
@@ -9,6 +9,10 @@ pub struct ConfigureArgs {
     /// Server URL to save (skips interactive prompt)
     #[arg(long)]
     pub server: Option<String>,
+
+    /// API token to save (skips interactive prompt)
+    #[arg(long)]
+    pub token: Option<String>,
 }
 
 pub async fn run(args: ConfigureArgs) -> Result<()> {
@@ -31,11 +35,40 @@ pub async fn run(args: ConfigureArgs) -> Result<()> {
         }
     };
 
+    let token = match args.token {
+        Some(t) => Some(t),
+        None => {
+            let prompt = match &cfg.token {
+                Some(_) => "API token [unchanged, leave blank to keep]: ",
+                None => "API token [none, leave blank to skip]: ",
+            };
+            print!("{prompt}");
+            io::stdout().flush()?;
+            let mut input = String::new();
+            io::stdin().read_line(&mut input)?;
+            let input = input.trim();
+            if input.is_empty() {
+                cfg.token.clone()
+            } else {
+                Some(input.to_string())
+            }
+        }
+    };
+
     cfg.server = Some(server.clone());
+    cfg.token = token;
     config::save(&cfg)?;
 
     println!("Saved to {}", config::path_display());
     println!("  server = {server}");
+    println!(
+        "  token = {}",
+        if cfg.token.is_some() {
+            "<set>"
+        } else {
+            "<none>"
+        }
+    );
 
     Ok(())
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -5,6 +5,8 @@ use std::path::{Path, PathBuf};
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct Config {
     pub server: Option<String>,
+    #[serde(default)]
+    pub token: Option<String>,
 }
 
 fn config_path() -> Option<PathBuf> {
@@ -54,6 +56,7 @@ mod tests {
 
         let cfg = Config {
             server: Some("http://example.com:8000".to_string()),
+            token: None,
         };
         save_to(&path, &cfg).unwrap();
 
@@ -87,6 +90,7 @@ mod tests {
 
         let cfg = Config {
             server: Some("http://example.com".to_string()),
+            token: None,
         };
         save_to(&path, &cfg).unwrap();
         assert!(path.exists());

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,6 +16,10 @@ pub fn resolve_server(flag: Option<String>, cfg: &config::Config) -> String {
         .unwrap_or_else(|| DEFAULT_SERVER.to_string())
 }
 
+pub fn resolve_token(flag: Option<String>, cfg: &config::Config) -> Option<String> {
+    flag.or_else(|| cfg.token.clone())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -24,6 +28,7 @@ mod tests {
     fn cfg(server: Option<&str>) -> Config {
         Config {
             server: server.map(str::to_string),
+            token: None,
         }
     }
 
@@ -47,6 +52,36 @@ mod tests {
         let server = resolve_server(None, &cfg(None));
         assert_eq!(server, DEFAULT_SERVER);
     }
+
+    #[test]
+    fn token_flag_beats_config() {
+        let cfg = Config {
+            server: None,
+            token: Some("config-token".to_string()),
+        };
+        let token = resolve_token(Some("flag-token".to_string()), &cfg);
+        assert_eq!(token, Some("flag-token".to_string()));
+    }
+
+    #[test]
+    fn token_falls_back_to_config() {
+        let cfg = Config {
+            server: None,
+            token: Some("config-token".to_string()),
+        };
+        let token = resolve_token(None, &cfg);
+        assert_eq!(token, Some("config-token".to_string()));
+    }
+
+    #[test]
+    fn token_none_when_unset() {
+        let cfg = Config {
+            server: None,
+            token: None,
+        };
+        let token = resolve_token(None, &cfg);
+        assert_eq!(token, None);
+    }
 }
 
 #[derive(Parser)]
@@ -55,6 +90,10 @@ pub struct Cli {
     /// Server base URL (overrides config file and QARAX_SERVER env var)
     #[arg(long, env = "QARAX_SERVER", global = true)]
     pub server: Option<String>,
+
+    /// API token for authentication (overrides config file and QARAX_TOKEN env var)
+    #[arg(long, env = "QARAX_TOKEN", global = true)]
+    pub token: Option<String>,
 
     /// Output format (table, json, yaml)
     #[arg(
@@ -117,8 +156,9 @@ async fn main() -> Result<()> {
 
     let cfg = config::load();
     let server = resolve_server(cli.server, &cfg);
+    let token = resolve_token(cli.token, &cfg);
 
-    let client = client::Client::new(&server);
+    let client = client::Client::new(&server, token.as_deref());
 
     match cli.command {
         Commands::Backup(args) => commands::backup::run(args, &client, cli.output).await,

--- a/configuration/base.yaml
+++ b/configuration/base.yaml
@@ -25,3 +25,6 @@ ha:
 telemetry:
   otel_enabled: false
   otlp_endpoint: "http://localhost:4318"
+auth:
+  enabled: false
+  tokens: []

--- a/configuration/production.yaml
+++ b/configuration/production.yaml
@@ -8,3 +8,8 @@ vm_defaults:
   kernel: "/var/lib/qarax/images/vmlinux-production"
   initramfs: "/var/lib/qarax/images/initramfs-production.gz"
   cmdline: "console=ttyS0 root=/dev/vda rw"
+# API token auth must be enabled in production. Provide tokens via the
+# AUTH_TOKENS environment variable (comma-separated).
+auth:
+  enabled: true
+  tokens: []

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -24,6 +24,8 @@ from qarax_api_client.api.hosts import init as init_host
 from qarax_api_client.api.hosts import list_ as list_hosts
 from qarax_api_client.models.new_host import NewHost
 
+from helpers import AUTH_HEADERS
+
 QARAX_URL = os.getenv("QARAX_URL", "http://localhost:8000")
 # Address of qarax-node as seen from the qarax control plane (inside docker network)
 QARAX_NODE_HOST = os.getenv("QARAX_NODE_HOST", "qarax-node")
@@ -221,7 +223,7 @@ def telemetry_collector(_telemetry_store: _TelemetryStore) -> _TelemetryStore:
 @pytest.fixture(scope="session", autouse=True)
 def ensure_host_registered():
     """Register the qarax-node host and initialize it before tests run."""
-    client = Client(base_url=QARAX_URL)
+    client = Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
     hosts = list_hosts.sync(client=client)
     if hosts is None:

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -104,6 +104,9 @@ services:
       # Short HA windows so the failover e2e test completes quickly
       HA_FAILOVER_GRACE_SECONDS: ${HA_FAILOVER_GRACE_SECONDS:-5}
       HA_CHECK_INTERVAL_SECONDS: ${HA_CHECK_INTERVAL_SECONDS:-5}
+      # API token auth - tests authenticate with QARAX_TEST_TOKEN
+      AUTH_ENABLED: "true"
+      AUTH_TOKENS: ${QARAX_TEST_TOKEN:-e2e-test-token}
     ports:
       - "8000:8000"
     depends_on:

--- a/e2e/helpers.py
+++ b/e2e/helpers.py
@@ -8,6 +8,8 @@ from qarax_api_client.api.vms import get as get_vm
 from qarax_api_client.models import HostStatus, VmStatus
 
 QARAX_URL = os.getenv("QARAX_URL", "http://localhost:8000")
+QARAX_TEST_TOKEN = os.getenv("QARAX_TEST_TOKEN", "e2e-test-token")
+AUTH_HEADERS = {"Authorization": f"Bearer {QARAX_TEST_TOKEN}"}
 VM_OPERATION_TIMEOUT = 30
 
 

--- a/e2e/run_e2e_tests.sh
+++ b/e2e/run_e2e_tests.sh
@@ -24,6 +24,11 @@ export CLOUD_HYPERVISOR_VERSION
 : "${FIRECRACKER_VERSION:=$(cat ../versions/firecracker-version)}"
 export FIRECRACKER_VERSION
 
+# qarax CLI auth token, must match AUTH_TOKENS configured for the qarax
+# service in docker-compose.yml (see e2e/helpers.py).
+: "${QARAX_TOKEN:=${QARAX_TEST_TOKEN:-e2e-test-token}}"
+export QARAX_TOKEN
+
 default_webhook_host() {
 	if [ "$(uname -s)" != "Linux" ]; then
 		echo "host.docker.internal"

--- a/e2e/test_audit_log.py
+++ b/e2e/test_audit_log.py
@@ -11,6 +11,8 @@ import uuid
 import httpx
 import pytest
 
+from helpers import AUTH_HEADERS
+
 QARAX_URL = os.getenv("QARAX_URL", "http://localhost:8000")
 
 
@@ -29,7 +31,7 @@ def list_audit_logs(
         params["action"] = action
     if limit is not None:
         params["limit"] = limit
-    resp = httpx.get(f"{QARAX_URL}/audit-logs", params=params)
+    resp = httpx.get(f"{QARAX_URL}/audit-logs", params=params, headers=AUTH_HEADERS)
     resp.raise_for_status()
     return resp.json()
 
@@ -43,13 +45,13 @@ def create_host() -> dict[str, str]:
         "host_user": "root",
         "password": "",
     }
-    resp = httpx.post(f"{QARAX_URL}/hosts", json=host)
+    resp = httpx.post(f"{QARAX_URL}/hosts", json=host, headers=AUTH_HEADERS)
     resp.raise_for_status()
     return {"id": resp.text.strip(), "name": host["name"]}
 
 
 def get_audit_log(audit_log_id: str) -> dict:
-    resp = httpx.get(f"{QARAX_URL}/audit-logs/{audit_log_id}")
+    resp = httpx.get(f"{QARAX_URL}/audit-logs/{audit_log_id}", headers=AUTH_HEADERS)
     resp.raise_for_status()
     return resp.json()
 
@@ -133,11 +135,13 @@ def test_audit_log_limit_param():
 def test_audit_log_get_not_found():
     """GET /audit-logs/{id} returns 404 for a non-existent ID."""
     non_existent = "00000000-0000-0000-0000-000000000000"
-    resp = httpx.get(f"{QARAX_URL}/audit-logs/{non_existent}")
+    resp = httpx.get(f"{QARAX_URL}/audit-logs/{non_existent}", headers=AUTH_HEADERS)
     assert resp.status_code == 404
 
 
 def test_audit_log_invalid_action_filter_returns_400():
     """Invalid action filters should be rejected instead of ignored."""
-    resp = httpx.get(f"{QARAX_URL}/audit-logs", params={"action": "not-a-real-action"})
+    resp = httpx.get(
+        f"{QARAX_URL}/audit-logs", params={"action": "not-a-real-action"}, headers=AUTH_HEADERS
+    )
     assert resp.status_code == 400

--- a/e2e/test_auth.py
+++ b/e2e/test_auth.py
@@ -1,0 +1,34 @@
+"""E2E tests for API token authentication."""
+
+import httpx
+import pytest
+
+from helpers import AUTH_HEADERS, QARAX_URL
+
+
+def test_protected_endpoint_requires_auth():
+    """GET /hosts without an Authorization header is rejected."""
+    resp = httpx.get(f"{QARAX_URL}/hosts")
+    assert resp.status_code == 401
+
+
+def test_protected_endpoint_rejects_wrong_token():
+    """GET /hosts with an incorrect bearer token is rejected."""
+    resp = httpx.get(f"{QARAX_URL}/hosts", headers={"Authorization": "Bearer not-the-right-token"})
+    assert resp.status_code == 401
+
+
+def test_protected_endpoint_accepts_valid_token():
+    """GET /hosts with the configured bearer token succeeds."""
+    resp = httpx.get(f"{QARAX_URL}/hosts", headers=AUTH_HEADERS)
+    assert resp.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/", "/swagger-ui", "/api-docs/openapi.json"],
+)
+def test_public_paths_do_not_require_auth(path):
+    """Health check, Swagger UI, and the OpenAPI spec remain accessible without auth."""
+    resp = httpx.get(f"{QARAX_URL}{path}", follow_redirects=True)
+    assert resp.status_code == 200

--- a/e2e/test_backups.py
+++ b/e2e/test_backups.py
@@ -32,20 +32,20 @@ from qarax_api_client.models import (
 )
 from qarax_api_client.models.attach_pool_host_request import AttachPoolHostRequest
 
-from helpers import QARAX_URL, wait_for_status
+from helpers import AUTH_HEADERS, QARAX_URL, wait_for_status
 
 VM_OPERATION_TIMEOUT = 60
 
 
 @pytest.fixture
 def client():
-    return Client(base_url=QARAX_URL)
+    return Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
 
 @pytest.fixture(scope="module")
 def backup_storage_pool():
     """Create a local storage pool backed by the control-plane filesystem."""
-    with Client(base_url=QARAX_URL) as c:
+    with Client(base_url=QARAX_URL, headers=AUTH_HEADERS) as c:
         hosts = [h for h in (list_hosts.sync(client=c) or []) if h.status == HostStatus.UP]
         assert hosts, "No UP hosts registered"
         host_id = hosts[0].id

--- a/e2e/test_cloud_init.py
+++ b/e2e/test_cloud_init.py
@@ -19,7 +19,7 @@ from qarax_api_client.api.vms import (
 )
 from qarax_api_client.models import Hypervisor, NewVm, VmStatus
 
-from helpers import QARAX_URL, wait_for_status
+from helpers import AUTH_HEADERS, QARAX_URL, wait_for_status
 
 VM_OPERATION_TIMEOUT = 30
 
@@ -49,7 +49,7 @@ config:
 
 @pytest.fixture
 def client():
-    return Client(base_url=QARAX_URL)
+    return Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
 
 @pytest.mark.asyncio

--- a/e2e/test_db.py
+++ b/e2e/test_db.py
@@ -5,13 +5,14 @@ from qarax_api_client.api.hosts import list_ as list_hosts
 from qarax_api_client.models import NewNetwork
 from qarax_api_client.models.attach_host_request import AttachHostRequest
 from qarax_api_client import Client
+from helpers import AUTH_HEADERS
 import uuid
 
 async def run():
     import contextlib
     @contextlib.asynccontextmanager
     async def make_client():
-        c = Client(base_url=QARAX_URL)
+        c = Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
         yield c
         
     async with make_client() as c:

--- a/e2e/test_disk_resize.py
+++ b/e2e/test_disk_resize.py
@@ -68,7 +68,7 @@ from qarax_api_client.models.disk_resize_request import DiskResizeRequest
 from qarax_api_client.models.new_storage_object import NewStorageObject
 from qarax_api_client.models.storage_object_type import StorageObjectType
 
-from helpers import QARAX_URL, wait_for_status
+from helpers import AUTH_HEADERS, QARAX_URL, wait_for_status
 from helpers import up_hosts as _up_hosts
 
 VM_OPERATION_TIMEOUT = 30
@@ -85,7 +85,7 @@ TEST_FILE_PATH = "/var/lib/qarax/images/test-initramfs.gz"
 
 @pytest.fixture
 def client():
-    return Client(base_url=QARAX_URL)
+    return Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
 
 def _node_container_names():

--- a/e2e/test_firecracker.py
+++ b/e2e/test_firecracker.py
@@ -50,19 +50,19 @@ from qarax_api_client.models import (
     VmStatus,
 )
 
-from helpers import QARAX_URL, call_api, call_api_detailed, wait_for_status
+from helpers import AUTH_HEADERS, QARAX_URL, call_api, call_api_detailed, wait_for_status
 
 
 @pytest.fixture
 def client():
     """Create a qarax API client."""
-    return Client(base_url=QARAX_URL)
+    return Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
 
 @pytest.fixture(scope="module")
 def fc_snapshot_storage_pool():
     """Create a local storage pool for FC snapshot tests and attach it to a UP host."""
-    with Client(base_url=QARAX_URL) as c:
+    with Client(base_url=QARAX_URL, headers=AUTH_HEADERS) as c:
         hosts = [h for h in (list_hosts.sync(client=c) or []) if h.status == HostStatus.UP]
         assert hosts, "No UP hosts registered"
         host_id = hosts[0].id

--- a/e2e/test_gpu_scheduling.py
+++ b/e2e/test_gpu_scheduling.py
@@ -11,6 +11,7 @@ import os
 
 import pytest
 from qarax_api_client import Client
+from helpers import AUTH_HEADERS
 from qarax_api_client.api.hosts import list_ as list_hosts
 from qarax_api_client.api.instance_types import (
     create as create_instance_type,
@@ -30,13 +31,13 @@ QARAX_URL = os.getenv("QARAX_URL", "http://localhost:8000")
 @pytest.fixture
 def client():
     """Create a qarax API client."""
-    return Client(base_url=QARAX_URL)
+    return Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
 
 @pytest.fixture
 def http_client():
     """Create a raw HTTP client for endpoints not yet in the generated SDK."""
-    return httpx.Client(base_url=QARAX_URL)
+    return httpx.Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
 
 def get_first_host_id(client):

--- a/e2e/test_ha_failover.py
+++ b/e2e/test_ha_failover.py
@@ -29,6 +29,7 @@ from uuid import UUID
 import httpx
 import pytest
 from qarax_api_client import Client
+from helpers import AUTH_HEADERS
 from qarax_api_client.api.hosts import add as add_host
 from qarax_api_client.api.hosts import init as init_host
 from qarax_api_client.api.hosts import list_ as list_hosts
@@ -56,7 +57,7 @@ FAILOVER_TIMEOUT = 180
 
 @pytest.fixture
 def client():
-    return Client(base_url=QARAX_URL)
+    return Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
 
 def _register_and_init_host(client, address, port, name):
@@ -93,7 +94,7 @@ def _register_and_init_host(client, address, port, name):
 @pytest.fixture(scope="module")
 def two_hosts():
     """Ensure both qarax-node instances are registered and initialized. Returns (host1_id, host2_id)."""
-    c = Client(base_url=QARAX_URL)
+    c = Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
     host1_id = _register_and_init_host(
         c, QARAX_NODE_HOST, QARAX_NODE_PORT, "e2e-node-1"
     )
@@ -172,7 +173,7 @@ async def _create_vm_raw(http_client, *, name, ha_enabled):
 @pytest.mark.asyncio
 async def test_ha_enabled_is_persisted(client, two_hosts):
     """ha_enabled survives the round trip through create and get."""
-    async with httpx.AsyncClient(base_url=QARAX_URL) as http_client:
+    async with httpx.AsyncClient(base_url=QARAX_URL, headers=AUTH_HEADERS) as http_client:
         vm_id = await _create_vm_raw(
             http_client, name=f"e2e-ha-flag-{uuid.uuid4().hex[:6]}", ha_enabled=True
         )
@@ -201,7 +202,7 @@ async def test_ha_failover_on_host_failure(client, two_hosts):
     dead_host_id = None
     stopped_service = None
 
-    async with client as c, httpx.AsyncClient(base_url=QARAX_URL) as http_client:
+    async with client as c, httpx.AsyncClient(base_url=QARAX_URL, headers=AUTH_HEADERS) as http_client:
         try:
             # Pin both VMs to host1 by putting host2 in maintenance.
             await update_host.asyncio_detailed(

--- a/e2e/test_hotplug.py
+++ b/e2e/test_hotplug.py
@@ -71,12 +71,12 @@ from qarax_api_client.models.storage_object_type import StorageObjectType
 NFS_SERVER_HOST = os.getenv("NFS_SERVER_HOST", "nfs-server")
 NFS_EXPORT_PATH = os.getenv("NFS_EXPORT_PATH", "/nfs-export")
 
-from helpers import QARAX_URL, call_api, up_hosts as _up_hosts, wait_for_status
+from helpers import AUTH_HEADERS, QARAX_URL, call_api, up_hosts as _up_hosts, wait_for_status
 
 
 @pytest.fixture
 def client():
-    return Client(base_url=QARAX_URL)
+    return Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
 
 async def _make_nfs_pool(c, test_id, hosts):

--- a/e2e/test_lifecycle_hooks.py
+++ b/e2e/test_lifecycle_hooks.py
@@ -117,15 +117,15 @@ def webhook_server():
 
 @pytest.fixture
 def client():
-    return Client(base_url=QARAX_URL)
+    return Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
 
 @pytest.fixture
 def http_client():
-    return httpx.Client(base_url=QARAX_URL)
+    return httpx.Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
 
-from helpers import call_api, wait_for_status
+from helpers import AUTH_HEADERS, call_api, wait_for_status
 
 
 # ---------------------------------------------------------------------------

--- a/e2e/test_live_migration.py
+++ b/e2e/test_live_migration.py
@@ -26,6 +26,7 @@ from uuid import UUID
 import httpx
 import pytest
 from qarax_api_client import Client
+from helpers import AUTH_HEADERS
 from qarax_api_client.api.hosts import add as add_host
 from qarax_api_client.api.hosts import evacuate as evacuate_host
 from qarax_api_client.api.hosts import init as init_host
@@ -77,7 +78,7 @@ MIGRATION_TIMEOUT = 120
 
 @pytest.fixture
 def client():
-    return Client(base_url=QARAX_URL)
+    return Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
 
 def _register_and_init_host(client, address, port, name):
@@ -114,7 +115,7 @@ def _register_and_init_host(client, address, port, name):
 @pytest.fixture(scope="module")
 def two_hosts():
     """Ensure both qarax-node instances are registered and initialized. Returns (host1_id, host2_id)."""
-    c = Client(base_url=QARAX_URL)
+    c = Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
     host1_id = _register_and_init_host(
         c, QARAX_NODE_HOST, QARAX_NODE_PORT, "e2e-node-1"
     )
@@ -522,7 +523,7 @@ async def test_scheduler_placement_policy_reservation_anti_affinity_and_spread(
     anti_vm_id = None
     spread_vm_ids: list[UUID] = []
 
-    async with client as c, httpx.AsyncClient(base_url=QARAX_URL) as http_client:
+    async with client as c, httpx.AsyncClient(base_url=QARAX_URL, headers=AUTH_HEADERS) as http_client:
         try:
             await _update_host_placement(
                 http_client, host1_id, reservation_class=reservation_class

--- a/e2e/test_network.py
+++ b/e2e/test_network.py
@@ -30,13 +30,13 @@ from qarax_api_client.models import (
 )
 
 
-from helpers import QARAX_URL, call_api, up_hosts as _up_hosts, wait_for_status
+from helpers import AUTH_HEADERS, QARAX_URL, call_api, up_hosts as _up_hosts, wait_for_status
 
 
 @pytest.fixture
 def client():
     """Create a qarax API client."""
-    return Client(base_url=QARAX_URL)
+    return Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
 
 @pytest.mark.asyncio
@@ -268,7 +268,7 @@ async def test_vpc_routing_and_security_group_updates(client):
         net_a_id = None
         net_b_id = None
 
-        async with httpx.AsyncClient(base_url=QARAX_URL, timeout=30.0) as raw:
+        async with httpx.AsyncClient(base_url=QARAX_URL, timeout=30.0, headers=AUTH_HEADERS) as raw:
             try:
                 net_a_resp = await raw.post(
                     "/networks",

--- a/e2e/test_node_upgrade.py
+++ b/e2e/test_node_upgrade.py
@@ -30,6 +30,7 @@ import uuid
 
 import pytest
 from qarax_api_client import Client
+from helpers import AUTH_HEADERS
 from qarax_api_client.api.hosts import add as add_host
 from qarax_api_client.api.hosts import deploy as deploy_host
 from qarax_api_client.api.hosts import init as init_host
@@ -121,7 +122,7 @@ def upgrade_host_id():
             f"upgrade node {UPGRADE_TEST_NODE_HOST}:{UPGRADE_TEST_NODE_PORT} is not reachable"
         )
 
-    client = Client(base_url=QARAX_URL)
+    client = Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
     host_name = f"bootc-vm-{uuid.uuid4().hex[:8]}"
 
     result = add_host.sync_detailed(
@@ -163,7 +164,7 @@ def upgrade_host_id():
 
 def test_init_populates_node_version(upgrade_host_id):
     """After init, the host should have a non-null node_version."""
-    client = Client(base_url=QARAX_URL)
+    client = Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
     host = get_host(client, upgrade_host_id)
     assert host.status == HostStatus.UP
     assert host.node_version is not None, "node_version should be set after init"
@@ -181,7 +182,7 @@ def test_deploy_sets_last_deployed_image_and_node_version(upgrade_host_id):
       - last_deployed_image is recorded
       - After re-init, node_version == "0.1.0"
     """
-    client = Client(base_url=QARAX_URL)
+    client = Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
     result = deploy_host.sync_detailed(
         host_id=upgrade_host_id,
@@ -227,7 +228,7 @@ def test_upgrade_uses_stored_credentials_and_updates_version(upgrade_host_id):
       - Host: installing → up (real VM reboot occurs)
       - Re-init: node_version still "0.2.0-test" (same image re-deployed)
     """
-    client = Client(base_url=QARAX_URL)
+    client = Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
     # Deploy v2 to set last_deployed_image
     result = deploy_host.sync_detailed(

--- a/e2e/test_numa.py
+++ b/e2e/test_numa.py
@@ -24,12 +24,12 @@ from qarax_api_client.models import NewVm, Hypervisor, VmStatus
 
 VM_OPERATION_TIMEOUT = 60
 
-from helpers import QARAX_URL, call_api, up_hosts as _up_hosts
+from helpers import AUTH_HEADERS, QARAX_URL, call_api, up_hosts as _up_hosts
 
 
 @pytest.fixture
 def client():
-    return Client(base_url=QARAX_URL)
+    return Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
 
 async def wait_for_vm_status(

--- a/e2e/test_resize.py
+++ b/e2e/test_resize.py
@@ -32,7 +32,7 @@ from qarax_api_client.api.vms import (
 from qarax_api_client.models import Hypervisor, NewVm, VmStatus
 from qarax_api_client.models.vm_resize_request import VmResizeRequest
 
-from helpers import QARAX_URL, wait_for_status
+from helpers import AUTH_HEADERS, QARAX_URL, wait_for_status
 
 VM_OPERATION_TIMEOUT = 30
 
@@ -45,7 +45,7 @@ MEMORY_HOTPLUG_SIZE = 256 * 1024 * 1024
 
 @pytest.fixture
 def client():
-    return Client(base_url=QARAX_URL)
+    return Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
 
 async def _make_resize_vm(c, test_id):

--- a/e2e/test_sandboxes.py
+++ b/e2e/test_sandboxes.py
@@ -7,6 +7,7 @@ import uuid
 
 import pytest
 from qarax_api_client import Client
+from helpers import AUTH_HEADERS
 from qarax_api_client.api.boot_sources import (
     create as create_boot_source,
     delete as delete_boot_source,
@@ -56,7 +57,7 @@ TRANSFER_TIMEOUT = 30
 
 @pytest.fixture
 def client():
-    return Client(base_url=QARAX_URL)
+    return Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
 
 async def create_bootable_sandbox_template(
@@ -232,7 +233,7 @@ async def cleanup_bootable_sandbox_template(client, resources):
 @pytest.fixture
 async def sandbox_template():
     """Create an explicitly bootable Cloud Hypervisor template for sandbox tests."""
-    async with Client(base_url=QARAX_URL) as c:
+    async with Client(base_url=QARAX_URL, headers=AUTH_HEADERS) as c:
         template_id, resources = await create_bootable_sandbox_template(c, "cloud_hv")
         yield template_id
         await cleanup_bootable_sandbox_template(c, resources)

--- a/e2e/test_snapshots.py
+++ b/e2e/test_snapshots.py
@@ -44,18 +44,18 @@ from qarax_api_client.models.snapshot_status import SnapshotStatus
 
 VM_OPERATION_TIMEOUT = 60
 
-from helpers import QARAX_URL, wait_for_status
+from helpers import AUTH_HEADERS, QARAX_URL, wait_for_status
 
 
 @pytest.fixture
 def client():
-    return Client(base_url=QARAX_URL)
+    return Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
 
 @pytest.fixture(scope="module")
 def snapshot_storage_pool():
     """Create a local storage pool for snapshot tests and attach it to the host."""
-    with Client(base_url=QARAX_URL) as c:
+    with Client(base_url=QARAX_URL, headers=AUTH_HEADERS) as c:
         hosts = [h for h in (list_hosts.sync(client=c) or []) if h.status == HostStatus.UP]
         assert hosts and len(hosts) > 0, "No UP hosts registered"
         host_id = hosts[0].id

--- a/e2e/test_storage_types.py
+++ b/e2e/test_storage_types.py
@@ -56,7 +56,7 @@ JOB_TIMEOUT = 120  # OCI image pull can take a while
 
 @pytest.fixture
 def client():
-    return Client(base_url=QARAX_URL)
+    return Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
 
 async def wait_for_job(c, job_id, timeout=JOB_TIMEOUT):
@@ -75,7 +75,7 @@ async def wait_for_job(c, job_id, timeout=JOB_TIMEOUT):
     raise TimeoutError(f"Job {job_id} did not complete within {timeout}s")
 
 
-from helpers import up_hosts as _up_hosts
+from helpers import AUTH_HEADERS, up_hosts as _up_hosts
 
 
 async def _create_pool(c, name, pool_type, config):

--- a/e2e/test_telemetry.py
+++ b/e2e/test_telemetry.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 from qarax_api_client import Client
+from helpers import AUTH_HEADERS
 from qarax_api_client.api.hosts import init as init_host
 from qarax_api_client.api.hosts import list_ as list_hosts
 
@@ -11,7 +12,7 @@ QARAX_NODE_HOST = os.getenv("QARAX_NODE_HOST", "qarax-node")
 
 @pytest.mark.telemetry
 def test_otel_exports_trace_propagation_and_metrics(telemetry_collector):
-    client = Client(base_url=QARAX_URL)
+    client = Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
     hosts = list_hosts.sync(client=client)
     assert hosts is not None
 

--- a/e2e/test_transfers.py
+++ b/e2e/test_transfers.py
@@ -40,13 +40,13 @@ from qarax_api_client.models.attach_host_request import AttachHostRequest
 
 TRANSFER_TIMEOUT = 30
 
-from helpers import QARAX_URL, up_hosts as _up_hosts
+from helpers import AUTH_HEADERS, QARAX_URL, up_hosts as _up_hosts
 
 
 @pytest.fixture
 def client():
     """Create a qarax API client."""
-    return Client(base_url=QARAX_URL)
+    return Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
 
 @pytest.mark.asyncio

--- a/e2e/test_vm_boot_mode.py
+++ b/e2e/test_vm_boot_mode.py
@@ -12,6 +12,7 @@ import os
 
 import pytest
 from qarax_api_client import Client
+from helpers import AUTH_HEADERS
 from qarax_api_client.api.hosts import list_ as list_hosts
 from qarax_api_client.api.storage_objects import (
     create as create_storage_object,
@@ -60,7 +61,7 @@ QARAX_URL = os.getenv("QARAX_URL", "http://localhost:8000")
 
 @pytest.fixture
 def client():
-    return Client(base_url=QARAX_URL)
+    return Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
 
 # boot_mode tests

--- a/e2e/test_vm_lifecycle.py
+++ b/e2e/test_vm_lifecycle.py
@@ -41,7 +41,7 @@ from qarax_api_client.models import (
 
 VM_OPERATION_TIMEOUT = 30
 
-from helpers import QARAX_URL, call_api, call_api_detailed, wait_for_status
+from helpers import AUTH_HEADERS, QARAX_URL, call_api, call_api_detailed, wait_for_status
 from test_sandboxes import (
     cleanup_bootable_sandbox_template,
     create_bootable_sandbox_template,
@@ -51,7 +51,7 @@ from test_sandboxes import (
 @pytest.fixture
 def client():
     """Create a qarax API client."""
-    return Client(base_url=QARAX_URL)
+    return Client(base_url=QARAX_URL, headers=AUTH_HEADERS)
 
 
 @pytest.mark.asyncio

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5621,6 +5621,12 @@ components:
           - string
           - 'null'
           format: uuid
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+security:
+- bearerAuth: []
 tags:
 - name: hosts
   description: Host management endpoints

--- a/python-sdk/qarax-api-client/qarax_api_client/api/audit_logs/get.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/audit_logs/get.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     audit_log_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/audit-logs/{audit_log_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/audit_logs/list_.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/audit_logs/list_.py
@@ -19,6 +19,7 @@ def _get_kwargs(
     action: AuditAction | None | Unset = UNSET,
     limit: int | None | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_resource_type: None | str | Unset

--- a/python-sdk/qarax-api-client/qarax_api_client/api/backups/get.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/backups/get.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     backup_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/backups/{backup_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/backups/list_.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/backups/list_.py
@@ -15,6 +15,7 @@ def _get_kwargs(
     name: None | str | Unset = UNSET,
     backup_type: BackupType | None | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_name: None | str | Unset

--- a/python-sdk/qarax-api-client/qarax_api_client/api/backups/restore.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/backups/restore.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     backup_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "post",
         "url": "/backups/{backup_id}/restore".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/boot_sources/delete.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/boot_sources/delete.py
@@ -13,6 +13,7 @@ from ...types import Response
 def _get_kwargs(
     boot_source_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/boot-sources/{boot_source_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/boot_sources/get.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/boot_sources/get.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     boot_source_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/boot-sources/{boot_source_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/boot_sources/list_.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/boot_sources/list_.py
@@ -13,6 +13,7 @@ def _get_kwargs(
     *,
     name: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_name: None | str | Unset

--- a/python-sdk/qarax-api-client/qarax_api_client/api/hooks/delete.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/hooks/delete.py
@@ -13,6 +13,7 @@ from ...types import Response
 def _get_kwargs(
     hook_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/hooks/{hook_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/hooks/get.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/hooks/get.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     hook_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/hooks/{hook_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/hooks/list_.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/hooks/list_.py
@@ -13,6 +13,7 @@ def _get_kwargs(
     *,
     name: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_name: None | str | Unset

--- a/python-sdk/qarax-api-client/qarax_api_client/api/hooks/list_executions.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/hooks/list_executions.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     hook_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/hooks/{hook_id}/executions".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/hosts/evacuate.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/hosts/evacuate.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     host_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "post",
         "url": "/hosts/{host_id}/evacuate".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/hosts/init.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/hosts/init.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     host_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "post",
         "url": "/hosts/{host_id}/init".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/hosts/list_.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/hosts/list_.py
@@ -14,6 +14,7 @@ def _get_kwargs(
     name: None | str | Unset = UNSET,
     architecture: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_name: None | str | Unset

--- a/python-sdk/qarax-api-client/qarax_api_client/api/hosts/list_gpus.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/hosts/list_gpus.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     host_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/hosts/{host_id}/gpus".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/hosts/list_numa_nodes.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/hosts/list_numa_nodes.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     host_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/hosts/{host_id}/numa".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/hosts/node_upgrade.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/hosts/node_upgrade.py
@@ -13,6 +13,7 @@ from ...types import Response
 def _get_kwargs(
     host_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "post",
         "url": "/hosts/{host_id}/upgrade".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/hosts/resources.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/hosts/resources.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     host_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/hosts/{host_id}/resources".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/instance_types/delete.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/instance_types/delete.py
@@ -13,6 +13,7 @@ from ...types import Response
 def _get_kwargs(
     instance_type_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/instance-types/{instance_type_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/instance_types/get.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/instance_types/get.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     instance_type_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/instance-types/{instance_type_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/instance_types/list_.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/instance_types/list_.py
@@ -13,6 +13,7 @@ def _get_kwargs(
     *,
     name: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_name: None | str | Unset

--- a/python-sdk/qarax-api-client/qarax_api_client/api/jobs/get.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/jobs/get.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     job_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/jobs/{job_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/networks/delete.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/networks/delete.py
@@ -13,6 +13,7 @@ from ...types import Response
 def _get_kwargs(
     network_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/networks/{network_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/networks/detach_host.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/networks/detach_host.py
@@ -14,6 +14,7 @@ def _get_kwargs(
     network_id: UUID,
     host_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/networks/{network_id}/hosts/{host_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/networks/get.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/networks/get.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     network_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/networks/{network_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/networks/list_.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/networks/list_.py
@@ -13,6 +13,7 @@ def _get_kwargs(
     *,
     name: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_name: None | str | Unset

--- a/python-sdk/qarax-api-client/qarax_api_client/api/networks/list_ips.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/networks/list_ips.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     network_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/networks/{network_id}/ips".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/sandbox_pools/delete.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/sandbox_pools/delete.py
@@ -13,6 +13,7 @@ from ...types import Response
 def _get_kwargs(
     vm_template_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/vm-templates/{vm_template_id}/sandbox-pool".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/sandbox_pools/get.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/sandbox_pools/get.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     vm_template_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/vm-templates/{vm_template_id}/sandbox-pool".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/sandbox_pools/list_.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/sandbox_pools/list_.py
@@ -10,6 +10,7 @@ from ...types import Response
 
 
 def _get_kwargs() -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/sandbox-pools",

--- a/python-sdk/qarax-api-client/qarax_api_client/api/sandboxes/delete.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/sandboxes/delete.py
@@ -13,6 +13,7 @@ from ...types import Response
 def _get_kwargs(
     sandbox_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/sandboxes/{sandbox_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/sandboxes/get.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/sandboxes/get.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     sandbox_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/sandboxes/{sandbox_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/sandboxes/keepalive.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/sandboxes/keepalive.py
@@ -13,6 +13,7 @@ from ...types import Response
 def _get_kwargs(
     sandbox_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "post",
         "url": "/sandboxes/{sandbox_id}/keepalive".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/sandboxes/list_.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/sandboxes/list_.py
@@ -10,6 +10,7 @@ from ...types import Response
 
 
 def _get_kwargs() -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/sandboxes",

--- a/python-sdk/qarax-api-client/qarax_api_client/api/scheduling/config.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/scheduling/config.py
@@ -10,6 +10,7 @@ from ...types import Response
 
 
 def _get_kwargs() -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/scheduling/config",

--- a/python-sdk/qarax-api-client/qarax_api_client/api/security_groups/delete.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/security_groups/delete.py
@@ -13,6 +13,7 @@ from ...types import Response
 def _get_kwargs(
     security_group_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/security-groups/{security_group_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/security_groups/delete_rule.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/security_groups/delete_rule.py
@@ -14,6 +14,7 @@ def _get_kwargs(
     security_group_id: UUID,
     rule_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/security-groups/{security_group_id}/rules/{rule_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/security_groups/get.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/security_groups/get.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     security_group_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/security-groups/{security_group_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/security_groups/list_.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/security_groups/list_.py
@@ -13,6 +13,7 @@ def _get_kwargs(
     *,
     name: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_name: None | str | Unset

--- a/python-sdk/qarax-api-client/qarax_api_client/api/security_groups/list_rules.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/security_groups/list_rules.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     security_group_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/security-groups/{security_group_id}/rules".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/storage_objects/delete.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/storage_objects/delete.py
@@ -13,6 +13,7 @@ from ...types import Response
 def _get_kwargs(
     object_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/storage-objects/{object_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/storage_objects/get.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/storage_objects/get.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     object_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/storage-objects/{object_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/storage_objects/list_.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/storage_objects/list_.py
@@ -17,6 +17,7 @@ def _get_kwargs(
     pool_id: None | Unset | UUID = UNSET,
     object_type: None | StorageObjectType | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_name: None | str | Unset

--- a/python-sdk/qarax-api-client/qarax_api_client/api/storage_pools/delete.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/storage_pools/delete.py
@@ -13,6 +13,7 @@ from ...types import Response
 def _get_kwargs(
     pool_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/storage-pools/{pool_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/storage_pools/detach_host.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/storage_pools/detach_host.py
@@ -14,6 +14,7 @@ def _get_kwargs(
     pool_id: UUID,
     host_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/storage-pools/{pool_id}/hosts/{host_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/storage_pools/get.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/storage_pools/get.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     pool_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/storage-pools/{pool_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/storage_pools/list_.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/storage_pools/list_.py
@@ -13,6 +13,7 @@ def _get_kwargs(
     *,
     name: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_name: None | str | Unset

--- a/python-sdk/qarax-api-client/qarax_api_client/api/transfers/get.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/transfers/get.py
@@ -15,6 +15,7 @@ def _get_kwargs(
     pool_id: UUID,
     transfer_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/storage-pools/{pool_id}/transfers/{transfer_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/transfers/list_.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/transfers/list_.py
@@ -16,6 +16,7 @@ def _get_kwargs(
     *,
     name: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_name: None | str | Unset

--- a/python-sdk/qarax-api-client/qarax_api_client/api/vm_templates/delete.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/vm_templates/delete.py
@@ -13,6 +13,7 @@ from ...types import Response
 def _get_kwargs(
     vm_template_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/vm-templates/{vm_template_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/vm_templates/get.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/vm_templates/get.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     vm_template_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/vm-templates/{vm_template_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/vm_templates/list_.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/vm_templates/list_.py
@@ -13,6 +13,7 @@ def _get_kwargs(
     *,
     name: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_name: None | str | Unset

--- a/python-sdk/qarax-api-client/qarax_api_client/api/vms/console_attach.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/vms/console_attach.py
@@ -13,6 +13,7 @@ from ...types import Response
 def _get_kwargs(
     vm_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/vms/{vm_id}/console/attach".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/vms/console_log.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/vms/console_log.py
@@ -13,6 +13,7 @@ from ...types import Response
 def _get_kwargs(
     vm_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/vms/{vm_id}/console".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/vms/delete.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/vms/delete.py
@@ -13,6 +13,7 @@ from ...types import Response
 def _get_kwargs(
     vm_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/vms/{vm_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/vms/detach_security_group.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/vms/detach_security_group.py
@@ -14,6 +14,7 @@ def _get_kwargs(
     vm_id: UUID,
     security_group_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/vms/{vm_id}/security-groups/{security_group_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/vms/force_stop.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/vms/force_stop.py
@@ -13,6 +13,7 @@ from ...types import Response
 def _get_kwargs(
     vm_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "post",
         "url": "/vms/{vm_id}/force-stop".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/vms/get.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/vms/get.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     vm_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/vms/{vm_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/vms/list_.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/vms/list_.py
@@ -14,6 +14,7 @@ def _get_kwargs(
     name: None | str | Unset = UNSET,
     tags: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_name: None | str | Unset

--- a/python-sdk/qarax-api-client/qarax_api_client/api/vms/list_nics.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/vms/list_nics.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     vm_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/vms/{vm_id}/nics".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/vms/list_security_groups.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/vms/list_security_groups.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     vm_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/vms/{vm_id}/security-groups".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/vms/list_snapshots.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/vms/list_snapshots.py
@@ -16,6 +16,7 @@ def _get_kwargs(
     *,
     name: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_name: None | str | Unset

--- a/python-sdk/qarax-api-client/qarax_api_client/api/vms/metrics.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/vms/metrics.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     vm_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/vms/{vm_id}/metrics".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/vms/pause.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/vms/pause.py
@@ -13,6 +13,7 @@ from ...types import Response
 def _get_kwargs(
     vm_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "post",
         "url": "/vms/{vm_id}/pause".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/vms/remove_disk.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/vms/remove_disk.py
@@ -14,6 +14,7 @@ def _get_kwargs(
     vm_id: UUID,
     device_id: str,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/vms/{vm_id}/disks/{device_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/vms/remove_nic.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/vms/remove_nic.py
@@ -14,6 +14,7 @@ def _get_kwargs(
     vm_id: UUID,
     device_id: str,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/vms/{vm_id}/nics/{device_id}".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/vms/resume.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/vms/resume.py
@@ -13,6 +13,7 @@ from ...types import Response
 def _get_kwargs(
     vm_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "post",
         "url": "/vms/{vm_id}/resume".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/vms/start.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/vms/start.py
@@ -14,6 +14,7 @@ from ...types import Response
 def _get_kwargs(
     vm_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "post",
         "url": "/vms/{vm_id}/start".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/api/vms/stop.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/api/vms/stop.py
@@ -13,6 +13,7 @@ from ...types import Response
 def _get_kwargs(
     vm_id: UUID,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "post",
         "url": "/vms/{vm_id}/stop".format(

--- a/python-sdk/qarax-api-client/qarax_api_client/models/host_placement_labels.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/models/host_placement_labels.py
@@ -15,6 +15,7 @@ class HostPlacementLabels:
     additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 

--- a/python-sdk/qarax-api-client/qarax_api_client/models/new_host_placement_labels.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/models/new_host_placement_labels.py
@@ -15,6 +15,7 @@ class NewHostPlacementLabels:
     additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 

--- a/python-sdk/qarax-api-client/qarax_api_client/models/placement_policy_preferred_host_labels.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/models/placement_policy_preferred_host_labels.py
@@ -15,6 +15,7 @@ class PlacementPolicyPreferredHostLabels:
     additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 

--- a/python-sdk/qarax-api-client/qarax_api_client/models/placement_policy_required_host_labels.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/models/placement_policy_required_host_labels.py
@@ -15,6 +15,7 @@ class PlacementPolicyRequiredHostLabels:
     additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 

--- a/python-sdk/qarax-api-client/qarax_api_client/models/update_host_placement_request_placement_labels.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/models/update_host_placement_request_placement_labels.py
@@ -15,6 +15,7 @@ class UpdateHostPlacementRequestPlacementLabels:
     additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 

--- a/python-sdk/qarax-api-client/qarax_api_client/models/vm_metrics_counters.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/models/vm_metrics_counters.py
@@ -19,6 +19,7 @@ class VmMetricsCounters:
     additional_properties: dict[str, VmMetricsCountersAdditionalProperty] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+
         field_dict: dict[str, Any] = {}
         for prop_name, prop in self.additional_properties.items():
             field_dict[prop_name] = prop.to_dict()

--- a/python-sdk/qarax-api-client/qarax_api_client/models/vm_metrics_counters_additional_property.py
+++ b/python-sdk/qarax-api-client/qarax_api_client/models/vm_metrics_counters_additional_property.py
@@ -15,6 +15,7 @@ class VmMetricsCountersAdditionalProperty:
     additional_properties: dict[str, int] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 

--- a/qarax/src/auth.rs
+++ b/qarax/src/auth.rs
@@ -1,0 +1,36 @@
+use axum::{
+    body::Body,
+    extract::State,
+    http::{Request, header::AUTHORIZATION},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+
+use crate::{App, errors::Error};
+
+/// Paths that remain reachable without an API token (health check and docs).
+fn is_public_path(path: &str) -> bool {
+    path == "/" || path == "/api-docs/openapi.json" || path.starts_with("/swagger-ui")
+}
+
+pub async fn require_api_token(
+    State(env): State<App>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let auth = env.auth();
+    if !auth.enabled || is_public_path(request.uri().path()) {
+        return next.run(request).await;
+    }
+
+    let token = request
+        .headers()
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "));
+
+    match token {
+        Some(token) if auth.tokens.iter().any(|t| t == token) => next.run(request).await,
+        _ => Error::Unauthorized.into_response(),
+    }
+}

--- a/qarax/src/configuration.rs
+++ b/qarax/src/configuration.rs
@@ -177,6 +177,16 @@ impl From<VmDefaultsSettingsRaw> for VmDefaultsSettings {
     }
 }
 
+#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
+pub struct AuthSettings {
+    /// Master switch for API token authentication.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Static bearer tokens accepted by the API.
+    #[serde(default)]
+    pub tokens: Vec<String>,
+}
+
 #[derive(serde::Deserialize, Debug, Default)]
 pub struct TelemetrySettings {
     /// Enable OpenTelemetry export (requires the `otel` feature at compile time)
@@ -205,6 +215,8 @@ pub struct Settings {
     pub ha: HaSettings,
     #[serde(default)]
     pub telemetry: TelemetrySettings,
+    #[serde(default)]
+    pub auth: AuthSettings,
 }
 
 #[derive(serde::Deserialize, Debug, Clone)]
@@ -339,6 +351,23 @@ pub fn get_configuration() -> Result<Settings, config::ConfigError> {
             std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
                 .ok()
                 .filter(|s| !s.is_empty()),
+        )?
+        // Override auth settings from environment variables if set and non-empty
+        .set_override_option(
+            "auth.enabled",
+            std::env::var("AUTH_ENABLED").ok().filter(|s| !s.is_empty()),
+        )?
+        .set_override_option(
+            "auth.tokens",
+            std::env::var("AUTH_TOKENS")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .map(|s| {
+                    s.split(',')
+                        .map(|t| t.trim().to_string())
+                        .filter(|t| !t.is_empty())
+                        .collect::<Vec<_>>()
+                }),
         )?
         .build()?;
     settings.try_deserialize::<Settings>()

--- a/qarax/src/errors.rs
+++ b/qarax/src/errors.rs
@@ -19,6 +19,9 @@ pub enum Error {
 
     #[error("not found")]
     NotFound,
+
+    #[error("missing or invalid API token")]
+    Unauthorized,
 }
 
 fn unique_violation_message(db_err: &dyn sqlx::error::DatabaseError) -> String {

--- a/qarax/src/ha_monitor.rs
+++ b/qarax/src/ha_monitor.rs
@@ -543,6 +543,7 @@ mod tests {
                 configuration.vm_defaults,
                 configuration.scheduling,
                 configuration.sandbox,
+                configuration.auth,
                 default_control_plane_architecture(),
             )
         }

--- a/qarax/src/handlers/mod.rs
+++ b/qarax/src/handlers/mod.rs
@@ -20,7 +20,10 @@ use tower_http::{
     request_id::{MakeRequestUuid, PropagateRequestIdLayer, RequestId, SetRequestIdLayer},
     trace::TraceLayer,
 };
-use utoipa::OpenApi;
+use utoipa::{
+    Modify, OpenApi,
+    openapi::security::{Http, HttpAuthScheme, SecurityScheme},
+};
 use utoipa_swagger_ui::SwaggerUi;
 use validator::ValidationErrors;
 
@@ -326,9 +329,23 @@ pub struct BackupListQuery {
         title = "Qarax API",
         version = "0.1.0",
         description = "REST API for managing virtual machines and hypervisor hosts"
-    )
+    ),
+    modifiers(&SecurityAddon),
+    security(("bearerAuth" = []))
 )]
 pub struct ApiDoc;
+
+struct SecurityAddon;
+
+impl Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        let components = openapi.components.get_or_insert_default();
+        components.add_security_scheme(
+            "bearerAuth",
+            SecurityScheme::Http(Http::new(HttpAuthScheme::Bearer)),
+        );
+    }
+}
 
 #[cfg(feature = "otel")]
 async fn record_http_metrics(
@@ -423,6 +440,10 @@ pub fn app(env: App) -> Router {
         .layer(middleware::from_fn_with_state(
             env.clone(),
             reject_maintenance_requests,
+        ))
+        .layer(middleware::from_fn_with_state(
+            env.clone(),
+            crate::auth::require_api_token,
         ))
         .layer(Extension(env.clone()))
         .layer(middleware::from_fn_with_state(
@@ -783,6 +804,7 @@ impl Error {
             InvalidEntity(_) | UnprocessableEntity(_) => StatusCode::UNPROCESSABLE_ENTITY,
             Conflict(_) => StatusCode::CONFLICT,
             NotFound => StatusCode::NOT_FOUND,
+            Unauthorized => StatusCode::UNAUTHORIZED,
         }
     }
 }

--- a/qarax/src/lib.rs
+++ b/qarax/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod configuration;
 pub mod database;
 pub mod errors;
@@ -23,7 +24,7 @@ use std::sync::{
 };
 
 use crate::configuration::{
-    DatabaseSettings, SandboxSettings, SchedulingSettings, VmDefaultsSettings,
+    AuthSettings, DatabaseSettings, SandboxSettings, SchedulingSettings, VmDefaultsSettings,
 };
 
 #[cfg(feature = "otel")]
@@ -36,6 +37,7 @@ pub struct App {
     vm_defaults: VmDefaultsSettings,
     scheduling: SchedulingSettings,
     sandbox: SandboxSettings,
+    auth: AuthSettings,
     control_plane_architecture: Arc<str>,
     maintenance_mode: Arc<AtomicBool>,
     #[cfg(feature = "otel")]
@@ -58,12 +60,14 @@ impl std::fmt::Debug for App {
 
 impl App {
     #[cfg(not(feature = "otel"))]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         pool: PgPool,
         database: DatabaseSettings,
         vm_defaults: VmDefaultsSettings,
         scheduling: SchedulingSettings,
         sandbox: SandboxSettings,
+        auth: AuthSettings,
         control_plane_architecture: String,
     ) -> Self {
         Self {
@@ -72,18 +76,21 @@ impl App {
             vm_defaults,
             scheduling,
             sandbox,
+            auth,
             control_plane_architecture: Arc::from(control_plane_architecture),
             maintenance_mode: Arc::new(AtomicBool::new(false)),
         }
     }
 
     #[cfg(feature = "otel")]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         pool: PgPool,
         database: DatabaseSettings,
         vm_defaults: VmDefaultsSettings,
         scheduling: SchedulingSettings,
         sandbox: SandboxSettings,
+        auth: AuthSettings,
         control_plane_architecture: String,
     ) -> Self {
         let meter = opentelemetry::global::meter("qarax");
@@ -93,6 +100,7 @@ impl App {
             vm_defaults,
             scheduling,
             sandbox,
+            auth,
             control_plane_architecture: Arc::from(control_plane_architecture),
             maintenance_mode: Arc::new(AtomicBool::new(false)),
             metrics: Arc::new(Metrics::new(&meter)),
@@ -121,6 +129,10 @@ impl App {
 
     pub fn sandbox(&self) -> &SandboxSettings {
         &self.sandbox
+    }
+
+    pub fn auth(&self) -> &AuthSettings {
+        &self.auth
     }
 
     pub fn control_plane_architecture(&self) -> &str {

--- a/qarax/src/main.rs
+++ b/qarax/src/main.rs
@@ -75,6 +75,7 @@ async fn main() -> std::io::Result<()> {
         vm_defaults,
         scheduling,
         sandbox,
+        configuration.auth.clone(),
         configuration.ha.clone(),
         default_control_plane_architecture(),
     )

--- a/qarax/src/resource_monitor.rs
+++ b/qarax/src/resource_monitor.rs
@@ -242,6 +242,7 @@ mod tests {
                 configuration.vm_defaults,
                 configuration.scheduling,
                 configuration.sandbox,
+                configuration.auth,
                 default_control_plane_architecture(),
             )
         }

--- a/qarax/src/startup.rs
+++ b/qarax/src/startup.rs
@@ -6,7 +6,8 @@ use sqlx::PgPool;
 use crate::{
     App,
     configuration::{
-        DatabaseSettings, HaSettings, SandboxSettings, SchedulingSettings, VmDefaultsSettings,
+        AuthSettings, DatabaseSettings, HaSettings, SandboxSettings, SchedulingSettings,
+        VmDefaultsSettings,
     },
     handlers::app,
 };
@@ -19,6 +20,7 @@ pub async fn run(
     vm_defaults: VmDefaultsSettings,
     scheduling: SchedulingSettings,
     sandbox: SandboxSettings,
+    auth: AuthSettings,
     ha: HaSettings,
     control_plane_architecture: String,
 ) -> Result<impl IntoFuture<Output = std::io::Result<()>> + Send, Box<dyn std::error::Error + Send>>
@@ -31,6 +33,7 @@ pub async fn run(
         vm_defaults,
         scheduling,
         sandbox,
+        auth,
         control_plane_architecture,
     );
 

--- a/qarax/tests/audit_logs.rs
+++ b/qarax/tests/audit_logs.rs
@@ -68,6 +68,7 @@ async fn spawn_app() -> TestApp {
         configuration.vm_defaults.clone(),
         configuration.scheduling.clone(),
         configuration.sandbox.clone(),
+        configuration.auth.clone(),
         configuration.ha.clone(),
         default_control_plane_architecture(),
     )

--- a/qarax/tests/auth.rs
+++ b/qarax/tests/auth.rs
@@ -3,8 +3,7 @@ use tokio::net::TcpListener;
 use common::telemtry::{get_subscriber, init_subscriber};
 use once_cell::sync::Lazy;
 use qarax::{
-    configuration::{DatabaseSettings, default_control_plane_architecture, get_configuration},
-    model::hosts::NewHost,
+    configuration::{AuthSettings, DatabaseSettings, default_control_plane_architecture},
     startup::run,
 };
 use reqwest::StatusCode;
@@ -15,7 +14,6 @@ use uuid::Uuid;
 struct TestApp {
     pub db_name: String,
     pub address: String,
-    pub _pool: PgPool,
 }
 
 static TRACING: Lazy<()> = Lazy::new(|| {
@@ -48,18 +46,16 @@ pub async fn configure_database(config: &DatabaseSettings) -> PgPool {
     connection_pool
 }
 
-async fn spawn_app() -> TestApp {
+async fn spawn_app(auth: AuthSettings) -> TestApp {
     Lazy::force(&TRACING);
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("Failed to bind random port");
     let port = listener.local_addr().unwrap().port();
     let address = format!("http://127.0.0.1:{}", port);
-    println!("Address: {}", address);
     let mut configuration =
         qarax::configuration::get_configuration().expect("Failed to read configuration.");
     configuration.database.name = Uuid::new_v4().to_string();
-    tracing::info!("Using database {}", configuration.database.name);
     let connection_pool = configure_database(&configuration.database).await;
 
     let server = run(
@@ -69,12 +65,12 @@ async fn spawn_app() -> TestApp {
         configuration.vm_defaults.clone(),
         configuration.scheduling.clone(),
         configuration.sandbox.clone(),
-        configuration.auth.clone(),
+        auth,
         configuration.ha.clone(),
         default_control_plane_architecture(),
     )
-    .await;
-    let server = server.unwrap();
+    .await
+    .unwrap();
     std::thread::spawn(move || {
         let rt = Runtime::new().unwrap();
         let _ = rt.block_on(async move { server.await });
@@ -82,62 +78,113 @@ async fn spawn_app() -> TestApp {
     TestApp {
         db_name: configuration.database.name,
         address,
-        _pool: connection_pool,
     }
-}
-
-#[tokio::test]
-async fn test_list_hosts_empty() {
-    let app = spawn_app().await;
-    let res: Result<reqwest::Response, reqwest::Error> =
-        reqwest::get(&format!("{}/hosts", &app.address)).await;
-    assert_eq!(res.unwrap().status(), StatusCode::OK);
-}
-
-#[tokio::test]
-async fn test_add_host() {
-    let app = spawn_app().await;
-    let host = NewHost {
-        name: String::from("test_host"),
-        address: String::from("127.0.0.1"),
-        port: 8080,
-        host_user: String::from("root"),
-        password: String::from("pass"),
-        reservation_class: None,
-        placement_labels: std::collections::BTreeMap::new(),
-    };
-    let client = reqwest::Client::new();
-    let res = client
-        .post(format!("{}/hosts", &app.address))
-        .header("Content-Type", "application/json")
-        .json(&host)
-        .send()
-        .await;
-    assert_eq!(res.unwrap().status(), StatusCode::CREATED);
 }
 
 impl Drop for TestApp {
     fn drop(&mut self) {
         let (tx, rx) = std::sync::mpsc::channel();
         let db_name = self.db_name.clone();
-
         std::thread::spawn(move || {
             let rt = Runtime::new().unwrap();
             rt.block_on(async {
-                let config = get_configuration().expect("Failed to read configuration");
+                let config = qarax::configuration::get_configuration()
+                    .expect("Failed to read configuration");
                 let mut conn = PgConnection::connect_with(&config.database.without_db())
                     .await
                     .expect("Failed to connect to Postgres");
-
                 conn.execute(&*format!("DROP DATABASE \"{}\" WITH (FORCE)", db_name))
                     .await
                     .expect("Failed to drop database.");
-
-                tracing::info!("Dropped database: {db_name}");
                 let _ = tx.send(());
             })
         });
-
         let _ = rx.recv();
     }
+}
+
+#[tokio::test]
+async fn test_auth_disabled_allows_unauthenticated_requests() {
+    let app = spawn_app(AuthSettings {
+        enabled: false,
+        tokens: vec![],
+    })
+    .await;
+
+    let res = reqwest::get(format!("{}/hosts", app.address))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_auth_enabled_rejects_missing_token() {
+    let app = spawn_app(AuthSettings {
+        enabled: true,
+        tokens: vec!["test-token".to_string()],
+    })
+    .await;
+
+    let res = reqwest::get(format!("{}/hosts", app.address))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_auth_enabled_rejects_wrong_token() {
+    let app = spawn_app(AuthSettings {
+        enabled: true,
+        tokens: vec!["test-token".to_string()],
+    })
+    .await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .get(format!("{}/hosts", app.address))
+        .bearer_auth("wrong-token")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_auth_enabled_accepts_valid_token() {
+    let app = spawn_app(AuthSettings {
+        enabled: true,
+        tokens: vec!["test-token".to_string()],
+    })
+    .await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .get(format!("{}/hosts", app.address))
+        .bearer_auth("test-token")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_auth_enabled_allows_public_paths_without_token() {
+    let app = spawn_app(AuthSettings {
+        enabled: true,
+        tokens: vec!["test-token".to_string()],
+    })
+    .await;
+
+    let res = reqwest::get(&app.address).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let res = reqwest::get(format!("{}/swagger-ui", app.address))
+        .await
+        .unwrap();
+    assert!(res.status().is_success() || res.status().is_redirection());
+
+    let res = reqwest::get(format!("{}/api-docs/openapi.json", app.address))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
 }

--- a/qarax/tests/sandbox_pools.rs
+++ b/qarax/tests/sandbox_pools.rs
@@ -66,6 +66,7 @@ async fn spawn_app() -> TestApp {
         configuration.vm_defaults.clone(),
         configuration.scheduling.clone(),
         configuration.sandbox.clone(),
+        configuration.auth.clone(),
         configuration.ha.clone(),
         default_control_plane_architecture(),
     )

--- a/qarax/tests/snapshots.rs
+++ b/qarax/tests/snapshots.rs
@@ -67,6 +67,7 @@ async fn spawn_app() -> TestApp {
         configuration.vm_defaults.clone(),
         configuration.scheduling.clone(),
         configuration.sandbox.clone(),
+        configuration.auth.clone(),
         configuration.ha.clone(),
         default_control_plane_architecture(),
     )

--- a/qarax/tests/storage_cleanup.rs
+++ b/qarax/tests/storage_cleanup.rs
@@ -74,6 +74,7 @@ async fn spawn_app() -> TestApp {
         configuration.vm_defaults.clone(),
         configuration.scheduling.clone(),
         configuration.sandbox.clone(),
+        configuration.auth.clone(),
         configuration.ha.clone(),
         default_control_plane_architecture(),
     )

--- a/qarax/tests/storage_pools.rs
+++ b/qarax/tests/storage_pools.rs
@@ -73,6 +73,7 @@ async fn spawn_app() -> TestApp {
         configuration.vm_defaults.clone(),
         configuration.scheduling.clone(),
         configuration.sandbox.clone(),
+        configuration.auth.clone(),
         configuration.ha.clone(),
         default_control_plane_architecture(),
     )

--- a/qarax/tests/vm_templates.rs
+++ b/qarax/tests/vm_templates.rs
@@ -68,6 +68,7 @@ async fn spawn_app() -> TestApp {
         configuration.vm_defaults.clone(),
         configuration.scheduling.clone(),
         configuration.sandbox.clone(),
+        configuration.auth.clone(),
         configuration.ha.clone(),
         default_control_plane_architecture(),
     )

--- a/qarax/tests/vms.rs
+++ b/qarax/tests/vms.rs
@@ -68,6 +68,7 @@ async fn spawn_app() -> TestApp {
         configuration.vm_defaults.clone(),
         configuration.scheduling.clone(),
         configuration.sandbox.clone(),
+        configuration.auth.clone(),
         configuration.ha.clone(),
         default_control_plane_architecture(),
     )


### PR DESCRIPTION
## Summary
- Adds config-driven static bearer token auth for the control plane (`AuthSettings`, `AUTH_ENABLED`/`AUTH_TOKENS`), enforced by new Axum middleware on all routes except `/`, `/swagger-ui*`, and `/api-docs/openapi.json`.
- Registers a `bearerAuth` OpenAPI security scheme so Swagger UI shows an Authorize button; regenerates `openapi.yaml` and the Python SDK.
- Adds CLI `--token`/`QARAX_TOKEN` support (`qarax configure --token ...`), sent as `Authorization: Bearer <token>`.
- Enables auth in `production.yaml` and in the e2e Docker Compose stack (fixed test token), updating all e2e fixtures/clients to send it, and adds `e2e/test_auth.py`.
- Defaults to disabled for local dev/tests, so existing workflows are unaffected unless `AUTH_ENABLED=true`.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo nextest run` (149 tests) and `cargo nextest run -p cli` (12 tests)
- [x] `make run-local` smoke test: `GET /hosts` → 401 (no/wrong token), 200 (valid token); `/`, `/swagger-ui`, `/api-docs/openapi.json` → 200 without auth
- [x] CLI smoke test: `qarax host list` fails without token, succeeds after `qarax configure --token ...`